### PR TITLE
feat: phase-121/122/123/124 — gateway health, off-chain delta, IPFS f…

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -157,3 +157,19 @@ NEXT_PUBLIC_CLASSIC_LIQ_ISSUER=
 # RESET_PHASE_MINT_AMOUNT=1000000.0000000
 # Código del asset: default PHASELQ en `reset-phase.ts`. Override solo si usas otro código on-chain.
 # RESET_PHASE_ASSET_CODE=PHASERLIQ
+
+# ─── Feature flags (phase-121..124) — rolling delivery, default off ───────
+# Cada flag habilita un módulo aislado; rollback: unset o 0 y restart.
+# phase-121: gateway health dashboard con latency scoring (custodian-release GET + chamber UI)
+# NEXT_PUBLIC_FEATURE_PHASE_121=1
+# FEATURE_PHASE_121=1
+# phase-122: off-chain metadata delta storage (reduce rent on-chain, stub delta:<id>:<hash>)
+# NEXT_PUBLIC_FEATURE_PHASE_122=1
+# FEATURE_PHASE_122=1
+# phase-123: IPFS timeout fallback chain across providers (4s por gateway, 8s legacy)
+# NEXT_PUBLIC_FEATURE_PHASE_123=1
+# FEATURE_PHASE_123=1
+# NEXT_PUBLIC_PHASE_IPFS_GATEWAYS=https://w3s.link/ipfs,https://dweb.link/ipfs
+# phase-124: metadata version migration tool v1→v2 (scripts/reset-phase --migrate-metadata)
+# NEXT_PUBLIC_FEATURE_PHASE_124=1
+# FEATURE_PHASE_124=1

--- a/PROJECT_ARCHITECTURE.md
+++ b/PROJECT_ARCHITECTURE.md
@@ -122,10 +122,22 @@ Owns:
 - Testnet-only assumptions must be explicit in docs and code comments.
 - Any privileged operation must validate input shape and origin intent.
 
-## 10) Change-management rules
+## 10) Feature flags (rolling delivery)
+
+| Flag | Env | Purpose | Default | Rollback |
+|------|-----|---------|---------|----------|
+| `phase-121` | `NEXT_PUBLIC_FEATURE_PHASE_121` / `FEATURE_PHASE_121` | Gateway health dashboard with latency scoring | off | Unset var, restart — dashboard returns 404, protocol falls back to static gateway list |
+| `phase-122` | `NEXT_PUBLIC_FEATURE_PHASE_122` / `FEATURE_PHASE_122` | Off-chain metadata delta storage (reduce on-chain rent) | off | Unset var, restart — verify falls back to on-chain `token_uri`, off-chain files remain on disk (no ledger revert) |
+| `phase-123` | `NEXT_PUBLIC_FEATURE_PHASE_123` / `FEATURE_PHASE_123` | IPFS timeout fallback chain across providers | off | Unset var, restart — reverts to 8s sequential fallback; no data migration |
+| `phase-124` | `NEXT_PUBLIC_FEATURE_PHASE_124` / `FEATURE_PHASE_124` | Metadata version migration tool (v1→v2) | off | Unset var, restart — v2 payloads remain readable as v1 where additive; no destructive rewrite without `--apply` |
+
+Flags are read via `lib/feature-flags.ts:isFeatureEnabled`. Client flags use `NEXT_PUBLIC_*`, server also accepts `FEATURE_*`. Zero regression when off.
+
+## 11) Change-management rules
 
 - Architectural changes require updates to:
   - `PROJECT_ARCHITECTURE.md` (this file)
   - `docs/TECHNICAL.md`
   - relevant API docs
 - Contract/address changes require synchronized env and docs updates.
+- Flag-gated features must document rollback in this table and in `docs/TECHNICAL.md` § Feature Flags.

--- a/app/api/ipfs/[...cid]/route.ts
+++ b/app/api/ipfs/[...cid]/route.ts
@@ -1,4 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { fetchWithIpfsFallback } from "@/lib/phase-nft-metadata-build"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -9,12 +11,13 @@ const CORS = {
   "Access-Control-Allow-Headers": "Content-Type, Accept",
 } as const
 
-const GATEWAYS = [
-  "https://w3s.link/ipfs",
-  "https://dweb.link/ipfs",
-  "https://ipfs.io/ipfs",
-  "https://cloudflare-ipfs.com/ipfs",
-]
+// phase-123 wiring: uses isolated fallback chain with per-gateway timeout
+const IpfsCidParamSchema = z.array(z.string().min(1).max(128).regex(/^[A-Za-z0-9._-]+$/)).min(1).max(10)
+
+function isPhase123Enabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_123 ?? process.env.FEATURE_PHASE_123 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
 
 export async function OPTIONS() {
   return new NextResponse(null, { status: 204, headers: CORS })
@@ -25,37 +28,32 @@ export async function GET(
   context: { params: Promise<{ cid: string[] }> },
 ) {
   const { cid } = await context.params
-  if (!cid || cid.length === 0) {
-    return NextResponse.json({ error: "Missing CID" }, { status: 400, headers: CORS })
+  const parsed = IpfsCidParamSchema.safeParse(cid)
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Missing or invalid CID", details: parsed.error.flatten() }, { status: 400, headers: CORS })
   }
 
-  const ipfsPath = cid.join("/")
+  const ipfsPath = parsed.data.join("/")
 
-  for (const base of GATEWAYS) {
-    const url = `${base}/${ipfsPath}`
-    try {
-      const res = await fetch(url, {
-        signal: AbortSignal.timeout(8000),
-        headers: { Accept: "*/*" },
-      })
-      if (!res.ok) continue
-      const contentType = res.headers.get("content-type") ?? "application/octet-stream"
-      const body = await res.arrayBuffer()
-      return new NextResponse(body, {
-        status: 200,
-        headers: {
-          ...CORS,
-          "Content-Type": contentType,
-          "Cache-Control": "public, s-maxage=31536000, immutable",
-        },
-      })
-    } catch {
-      // try next gateway
-    }
+  // phase-123: isolated fallback chain (timeout per gateway, structured error)
+  const result = await fetchWithIpfsFallback(ipfsPath, {
+    config: isPhase123Enabled() ? { timeoutMs: 4000 } : { timeoutMs: 8000 },
+  })
+
+  if (result.ok) {
+    return new NextResponse(result.bytes, {
+      status: 200,
+      headers: {
+        ...CORS,
+        "Content-Type": result.contentType,
+        "Cache-Control": "public, s-maxage=31536000, immutable",
+        ...(isPhase123Enabled() ? { "X-Phase-Gateway": result.gateway, "X-Phase-Latency-Ms": String(result.latencyMs) } : {}),
+      },
+    })
   }
 
   return NextResponse.json(
-    { error: "IPFS content unavailable from all gateways." },
+    { error: "IPFS content unavailable from all gateways.", detail: result.error, perGateway: isPhase123Enabled() ? result.perGateway : undefined },
     { status: 502, headers: CORS },
   )
 }

--- a/app/api/metadata/[id]/route.ts
+++ b/app/api/metadata/[id]/route.ts
@@ -1,9 +1,18 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { StrKey } from "@stellar/stellar-sdk"
-import { buildPhaseTokenMetadataJson } from "@/lib/phase-nft-metadata-build"
+import { z } from "zod"
+import { buildPhaseTokenMetadataJson, PhaseMetadataRequestSchema } from "@/lib/phase-nft-metadata-build"
 import { phaseProtocolContractIdForServer } from "@/lib/phase-protocol"
 
 export const dynamic = "force-dynamic"
+
+// phase-123: feature flag check (rollback: unset NEXT_PUBLIC_FEATURE_PHASE_123)
+function isPhase123Enabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_123 ?? process.env.FEATURE_PHASE_123 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+const MetadataIdParamSchema = z.coerce.number().int().min(1).max(1_000_000)
 
 const corsJson = {
   "Access-Control-Allow-Origin": "*",
@@ -22,18 +31,44 @@ export async function GET(
   context: { params: Promise<{ id: string }> },
 ) {
   const { id } = await context.params
-  const tokenId = parseInt(id, 10)
-  if (!Number.isFinite(tokenId) || tokenId <= 0) {
+  const parsedId = MetadataIdParamSchema.safeParse(id)
+  if (!parsedId.success) {
     return NextResponse.json(
-      { error: "invalid id" },
+      { error: "invalid id", details: parsedId.error.flatten() },
       { status: 400, headers: { ...corsJson, "Content-Type": "application/json; charset=utf-8" } },
     )
   }
+  const tokenId = parsedId.data
 
   const cParam = request.nextUrl.searchParams.get("c")?.trim() ?? ""
   const contractId =
     cParam && StrKey.isValidContract(cParam) ? cParam : phaseProtocolContractIdForServer()
-  const payload = await buildPhaseTokenMetadataJson(contractId, tokenId)
+
+  // phase-123: validate contract+token pair when flag enabled (type-safe, structured error)
+  if (isPhase123Enabled()) {
+    const chk = PhaseMetadataRequestSchema.safeParse({ contractId, tokenId })
+    if (!chk.success) {
+      return NextResponse.json(
+        { error: "validation failed", details: chk.error.flatten() },
+        { status: 400, headers: { ...corsJson, "Content-Type": "application/json; charset=utf-8" } },
+      )
+    }
+  }
+
+  let payload: Awaited<ReturnType<typeof buildPhaseTokenMetadataJson>>
+  try {
+    payload = await buildPhaseTokenMetadataJson(contractId, tokenId)
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    // Structured error handling: don't leak internal, but log with flag context
+    if (isPhase123Enabled()) {
+      console.warn(`[phase-123] metadata build failed token=${tokenId} contract=${contractId.slice(0, 8)}…: ${msg}`)
+    }
+    return NextResponse.json(
+      { error: "metadata build failed", detail: msg.slice(0, 200) },
+      { status: 502, headers: { ...corsJson, "Content-Type": "application/json; charset=utf-8" } },
+    )
+  }
   if (!payload) {
     return NextResponse.json(
       { error: "not found" },
@@ -48,6 +83,7 @@ export async function GET(
         "Content-Type": "application/json; charset=utf-8",
         ...corsJson,
         "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+        ...(isPhase123Enabled() ? { "X-Phase-IPFS-Fallback": "enabled" } : {}),
       },
     },
   )

--- a/app/api/phase-nft/custodian-release/route.ts
+++ b/app/api/phase-nft/custodian-release/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server"
 import { Keypair, TransactionBuilder } from "@stellar/stellar-sdk"
+import { z } from "zod"
 import { classicLiqIssuerForStellarToml } from "@/lib/classic-liq"
 import {
   buildTransferPhaseNftTransaction,
   fetchTokenOwnerAddress,
+  getGatewayHealthSnapshot,
   getTransactionResult,
   NETWORK_PASSPHRASE,
   phaseProtocolContractIdForServer,
@@ -15,14 +17,53 @@ export const dynamic = "force-dynamic"
 
 const PHASE_PROTOCOL_CONTRACT = phaseProtocolContractIdForServer()
 
+// phase-121: gateway health dashboard flag (rollback: unset NEXT_PUBLIC_FEATURE_PHASE_121)
+function isPhase121Enabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_121 ?? process.env.FEATURE_PHASE_121 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+const CustodianReleaseBodySchema = z.object({
+  tokenId: z.union([z.number().int().min(1), z.string().regex(/^\d+$/).transform((s) => parseInt(s, 10))]).transform((v) => (typeof v === "string" ? parseInt(v, 10) : v)).pipe(z.number().int().min(1)),
+  recipientWallet: z.string().length(56).regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar address"),
+})
+
 type Body = {
   tokenId?: number | string
   recipientWallet?: string
 }
 
+// phase-121: GET health dashboard (operators: which gateway is slow)
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!isPhase121Enabled()) {
+    return NextResponse.json({ ok: false, error: "Gateway health dashboard disabled (phase-121 flag off). Enable NEXT_PUBLIC_FEATURE_PHASE_121=1." }, { status: 404 })
+  }
+  const wantJson = request.headers.get("accept")?.includes("application/json") ?? true
+  if (!wantJson) {
+    return NextResponse.json({ ok: false, error: "Accept: application/json required" }, { status: 400 })
+  }
+  const url = new URL(request.url)
+  const sort = url.searchParams.get("sort") ?? "score"
+  const limitRaw = url.searchParams.get("limit")
+  const limit = limitRaw ? Math.max(1, Math.min(50, parseInt(limitRaw, 10) || 20)) : 20
+  if (!["score", "latency", "uptime"].includes(sort)) {
+    return NextResponse.json({ ok: false, error: "Invalid sort (score|latency|uptime)" }, { status: 400 })
+  }
+  const snapshot = getGatewayHealthSnapshot()
+  let gateways = [...snapshot.gateways]
+  if (sort === "latency") gateways.sort((a, b) => a.avgLatencyMs - b.avgLatencyMs)
+  else if (sort === "uptime") gateways.sort((a, b) => b.uptime - a.uptime)
+  gateways = gateways.slice(0, limit)
+  return NextResponse.json(
+    { ok: true, enabled: snapshot.enabled, updatedAt: snapshot.updatedAt, bestGateway: snapshot.bestGateway, worstGateway: snapshot.worstGateway, gateways },
+    { headers: { "Cache-Control": "no-store", "X-Phase-Flag": "phase-121" } },
+  )
+}
+
 /**
  * Transfiere el NFT PHASE desde la cuenta custodia (emisor PHASELQ G…) al usuario.
  * El contrato exige `from.require_auth()`: solo puede firmar el custodio on-chain.
+ * phase-121: adds structured validation and gateway health telemetry (flag-gated).
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   let body: Body
@@ -30,6 +71,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     body = (await request.json()) as Body
   } catch {
     return NextResponse.json({ ok: false, error: "Invalid JSON." }, { status: 400 })
+  }
+
+  // phase-121: type-safe validation when flag enabled (structured error, no regression when off)
+  if (isPhase121Enabled()) {
+    const parsed = CustodianReleaseBodySchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: "Validation failed", details: parsed.error.flatten() }, { status: 400 })
+    }
+    // Use validated values for downstream logic
+    body.tokenId = parsed.data.tokenId
+    body.recipientWallet = parsed.data.recipientWallet
   }
 
   const rawId = body.tokenId
@@ -100,6 +152,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
+    const start = Date.now()
     const xdr = await buildTransferPhaseNftTransaction(issuerG, recipient, Math.floor(tokenId), { contractId: PHASE_PROTOCOL_CONTRACT })
     const tx = TransactionBuilder.fromXDR(xdr, NETWORK_PASSPHRASE)
     tx.sign(kp)
@@ -108,9 +161,26 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     if (hash) {
       await getTransactionResult(hash)
     }
-    return NextResponse.json({ ok: true, hash: hash ?? null, contractId: PHASE_PROTOCOL_CONTRACT, tokenId: Math.floor(tokenId) })
+    const latencyMs = Date.now() - start
+    // phase-121: record custodial flow latency for operator visibility (best-effort)
+    if (isPhase121Enabled()) {
+      try {
+        const { recordGatewayLatency } = await import("@/lib/gateway-health")
+        recordGatewayLatency("custodian:sendTransaction", latencyMs, true)
+      } catch { /* ignore */ }
+    }
+    return NextResponse.json(
+      { ok: true, hash: hash ?? null, contractId: PHASE_PROTOCOL_CONTRACT, tokenId: Math.floor(tokenId) },
+      { headers: isPhase121Enabled() ? { "X-Phase-Custodian-Latency-Ms": String(latencyMs) } : undefined },
+    )
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
+    if (isPhase121Enabled()) {
+      try {
+        const { recordGatewayLatency } = await import("@/lib/gateway-health")
+        recordGatewayLatency("custodian:sendTransaction", 0, false)
+      } catch { /* ignore */ }
+    }
     return NextResponse.json({ ok: false, error: msg }, { status: 502 })
   }
 }

--- a/app/api/phase-nft/verify/route.ts
+++ b/app/api/phase-nft/verify/route.ts
@@ -1,10 +1,22 @@
 import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
 import { fetchTokenOwnerAddress, phaseProtocolContractIdForServer } from "@/lib/phase-protocol"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 const PHASE_PROTOCOL_CONTRACT = phaseProtocolContractIdForServer()
+
+// phase-122: flag check (rollback: unset NEXT_PUBLIC_FEATURE_PHASE_122)
+function isPhase122Enabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_122 ?? process.env.FEATURE_PHASE_122 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+const VerifyBodySchema = z.object({
+  tokenId: z.union([z.number().int().min(1), z.string().regex(/^\d+$/).transform((s) => parseInt(s, 10))]).transform((v) => (typeof v === "string" ? parseInt(v, 10) : v)).pipe(z.number().int().min(1).max(1_000_000)),
+  walletAddress: z.string().regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar address").optional().or(z.literal("")),
+})
 
 type Body = {
   tokenId?: number | string
@@ -14,6 +26,7 @@ type Body = {
 /**
  * Comprueba que el utility NFT existe en ledger (`owner_of`).
  * Devuelve `viewerIsOwner` si se pasó `walletAddress`; el cliente usa eso para ocultar Collect cuando ya es dueño.
+ * phase-122: when delta enabled, also probes off-chain delta store and reports storage rent insight.
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   let body: Body
@@ -21,6 +34,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     body = (await request.json()) as Body
   } catch {
     return NextResponse.json({ ok: false, error: "Invalid JSON." }, { status: 400 })
+  }
+
+  // phase-122: structured validation when flag enabled
+  if (isPhase122Enabled()) {
+    const parsed = VerifyBodySchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: "Validation failed", details: parsed.error.flatten() }, { status: 400 })
+    }
+    body.tokenId = parsed.data.tokenId
+    body.walletAddress = parsed.data.walletAddress
   }
 
   const rawId = body.tokenId
@@ -56,11 +79,27 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const viewerIsOwner = wallet.length > 0 && owner.toUpperCase() === wallet.toUpperCase()
 
+  // phase-122: off-chain delta probe (flag-gated, best-effort, no regression)
+  let delta: { present: boolean; manifest?: unknown; error?: string } | null = null
+  if (isPhase122Enabled()) {
+    try {
+      const { fetchOffchainDelta } = await import("@/lib/offchain-delta")
+      const res = await fetchOffchainDelta(PHASE_PROTOCOL_CONTRACT, tid)
+      if (res.ok) delta = { present: true, manifest: res.manifest }
+      else if (res.code === "NOT_FOUND") delta = { present: false }
+      else delta = { present: false, error: res.error }
+    } catch (e) {
+      delta = { present: false, error: e instanceof Error ? e.message : String(e) }
+    }
+  }
+
   return NextResponse.json({
     ok: true,
     owner,
     viewerIsOwner,
     contractId: PHASE_PROTOCOL_CONTRACT,
     tokenId: tid,
+    ...(delta ? { delta } : {}),
+    ...(isPhase122Enabled() ? { storage: { onChainStub: `delta:${tid}:<hash8>`, note: "Full metadata off-chain (phase-122); on-chain holds stub only. Rollback: unset FEATURE_PHASE_122." } } : {}),
   })
 }

--- a/components/fusion-chamber.tsx
+++ b/components/fusion-chamber.tsx
@@ -18,6 +18,7 @@ import { fetchArtistAlias } from "@/lib/artist-profile-client"
 import { humanizePhaseHostErrorMessage } from "@/lib/phase-host-error"
 import { pickCopy } from "@/lib/phase-copy"
 import { cn } from "@/lib/utils"
+import { GatewayHealthDashboard } from "@/components/gateway-health-dashboard"
 import {
   buildClassicTrustlineTransactionXdr,
   classicLiqAssetConfigFromPublicEnv,
@@ -2634,22 +2635,25 @@ export function FusionChamber() {
                 </div>
                 <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-3 sm:px-4 sm:pb-5">
                   {address ? (
-                    <LiquidityFaucetControl
-                      address={address}
-                      tokenBalance={tokenBalance}
-                      onNarrativeLog={appendLog}
-                      onRefreshBalance={refreshStatus}
-                      compact
-                      freighterNftCollect={
-                        phased && phaseId != null && tokenOwnerLookupDone ? { tokenId: phaseId } : null
-                      }
-                      hideInlineMissionToggle={false}
-                      omitHeader={false}
-                      omitMissionChain={false}
-                      omitLiquidityLane={false}
-                      omitFreighterNftBlock={Boolean(issuerCustodyForCollect || isOwnerOnChain)}
-                      className="border-zinc-800/80 bg-zinc-900/30"
-                    />
+                    <>
+                      <LiquidityFaucetControl
+                        address={address}
+                        tokenBalance={tokenBalance}
+                        onNarrativeLog={appendLog}
+                        onRefreshBalance={refreshStatus}
+                        compact
+                        freighterNftCollect={
+                          phased && phaseId != null && tokenOwnerLookupDone ? { tokenId: phaseId } : null
+                        }
+                        hideInlineMissionToggle={false}
+                        omitHeader={false}
+                        omitMissionChain={false}
+                        omitLiquidityLane={false}
+                        omitFreighterNftBlock={Boolean(issuerCustodyForCollect || isOwnerOnChain)}
+                        className="border-zinc-800/80 bg-zinc-900/30"
+                      />
+                      <GatewayHealthDashboard className="mt-3" />
+                    </>
                   ) : (
                     <p className="py-8 text-center text-[12px] text-zinc-500">{ch.linkWallet}</p>
                   )}

--- a/components/gateway-health-dashboard.tsx
+++ b/components/gateway-health-dashboard.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { cn } from "@/lib/utils"
+
+type HealthEntry = {
+  gateway: string
+  avgLatencyMs: number
+  p95LatencyMs: number
+  score: number
+  uptime: number
+  lastStatus: string
+  totalRequests: number
+  successCount: number
+  failCount: number
+}
+
+type Snapshot = {
+  enabled: boolean
+  updatedAt: string
+  bestGateway: string | null
+  worstGateway: string | null
+  gateways: HealthEntry[]
+}
+
+function isPhase121Enabled(): boolean {
+  const v = (typeof process !== "undefined" ? (process.env.NEXT_PUBLIC_FEATURE_PHASE_121 ?? "") : "")?.trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+function scoreColor(score: number): string {
+  if (score >= 80) return "text-emerald-400 border-emerald-500/50 bg-emerald-950/30"
+  if (score >= 50) return "text-amber-400 border-amber-500/50 bg-amber-950/30"
+  return "text-red-400 border-red-500/50 bg-red-950/30"
+}
+
+export function GatewayHealthDashboard({ className }: { className?: string }) {
+  const [data, setData] = useState<Snapshot | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const enabled = isPhase121Enabled()
+
+  async function fetchHealth() {
+    if (!enabled) return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch("/api/phase-nft/custodian-release", { headers: { Accept: "application/json" }, cache: "no-store" })
+      if (res.status === 404) {
+        setError("Dashboard disabled (flag off)")
+        setData(null)
+        return
+      }
+      if (!res.ok) {
+        const txt = await res.text()
+        throw new Error(`HTTP ${res.status}: ${txt.slice(0, 120)}`)
+      }
+      const json = (await res.json()) as Snapshot & { ok?: boolean }
+      if (json && "gateways" in json) setData(json as Snapshot)
+      else setError("Invalid response")
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!enabled) return
+    void fetchHealth()
+    const id = window.setInterval(() => {
+      if (document.visibilityState === "visible") void fetchHealth()
+    }, 15000)
+    return () => window.clearInterval(id)
+  }, [enabled])
+
+  if (!enabled) return null
+
+  return (
+    <div className={cn("rounded-sm border border-zinc-800 bg-zinc-900/40 p-3", className)}>
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-300">Gateway Health · phase-121</h3>
+        <button
+          type="button"
+          onClick={() => void fetchHealth()}
+          disabled={loading}
+          className="rounded-sm border border-zinc-700 bg-zinc-800 px-2 py-1 text-[10px] font-bold uppercase tracking-widest text-zinc-300 hover:border-violet-500/50 disabled:opacity-50"
+        >
+          {loading ? "Sync…" : "Refresh"}
+        </button>
+      </div>
+      {error ? <p className="text-[11px] text-red-400">{error}</p> : null}
+      {!data && !error ? <p className="text-[11px] text-zinc-500">{loading ? "Loading…" : "No data yet"}</p> : null}
+      {data ? (
+        <>
+          <p className="mb-2 text-[10px] text-zinc-500">Updated {new Date(data.updatedAt).toLocaleTimeString()} · best: {data.bestGateway ? new URL(data.bestGateway).host : "—"} · worst: {data.worstGateway ? new URL(data.worstGateway).host : "—"}</p>
+          <div className="space-y-1.5">
+            {data.gateways.map((g) => (
+              <div key={g.gateway} className={cn("flex items-center justify-between rounded-sm border px-2 py-1.5", scoreColor(g.score))}>
+                <span className="truncate pr-2 text-[10px] font-mono">{g.gateway.replace("https://", "").replace("/ipfs", "")}</span>
+                <span className="shrink-0 text-[10px] font-bold">{g.score} · {g.avgLatencyMs}ms · {Math.round(g.uptime * 100)}% · {g.lastStatus}</span>
+              </div>
+            ))}
+          </div>
+          <p className="mt-2 text-[9px] leading-relaxed text-zinc-600">Rollback: unset NEXT_PUBLIC_FEATURE_PHASE_121 and restart. No ledger change.</p>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/components/phase-protected-preview.tsx
+++ b/components/phase-protected-preview.tsx
@@ -4,6 +4,23 @@ import { IpfsDisplayImg } from "@/components/ipfs-display-img"
 import { cn } from "@/lib/utils"
 import { viewerSignatureShort } from "@/lib/viewer-signature"
 
+// ── phase-122: off-chain delta display hint (flag-gated, zero regression when off) ──
+function isPhase122Enabled(): boolean {
+  const v = (typeof process !== "undefined" ? (process.env.NEXT_PUBLIC_FEATURE_PHASE_122 ?? "") : "")?.trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+function isDeltaStub(uri: string): boolean {
+  return /^delta:\d+:[a-f0-9]{8}$/i.test(uri.trim())
+}
+
+function resolveDisplayUri(uri: string): string {
+  // Delta stub is resolved server-side via /api/phase-nft/verify delta probe;
+  // here we just pass through unless flag enables delta-aware proxy.
+  if (isPhase122Enabled() && isDeltaStub(uri)) return "" // caller should fetch full metadata off-chain
+  return uri
+}
+
 export type PhaseProtectedPreviewLabels = {
   pendingFusion: string
   unverifiedCopy: string
@@ -27,6 +44,8 @@ type Props = {
  */
 export function PhaseProtectedPreview({ uri, className, chainVerified, viewerAddress, labels }: Props) {
   const sig = viewerSignatureShort(viewerAddress)
+  const displayUri = resolveDisplayUri(uri)
+  const isDelta = isPhase122Enabled() && isDeltaStub(uri)
 
   return (
     <div
@@ -36,7 +55,7 @@ export function PhaseProtectedPreview({ uri, className, chainVerified, viewerAdd
       )}
     >
       <IpfsDisplayImg
-        uri={uri}
+        uri={displayUri || uri}
         className={cn(
           "relative z-0 max-h-full max-w-full object-contain p-2 transition-[filter] duration-300",
           chainVerified
@@ -45,6 +64,11 @@ export function PhaseProtectedPreview({ uri, className, chainVerified, viewerAdd
         )}
         loading="lazy"
       />
+      {isDelta ? (
+        <div className="pointer-events-none absolute left-1.5 top-1.5 z-[4] rounded-sm border border-cyan-500/40 bg-black/80 px-1 py-0.5 font-mono text-[6px] font-bold uppercase tracking-widest text-cyan-300/90">
+          Δ off-chain
+        </div>
+      ) : null}
 
       {!chainVerified && (
         <>

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -71,6 +71,11 @@ flowchart TB
 | `lib/classic-liq.ts` | Classic asset trustline utilities (`changeTrust` XDR, Horizon checks) |
 | `lib/phase-copy.ts` | Centralized i18n dictionary (EN/ES) |
 | `lib/server-data-paths.ts` | Writable data location abstraction |
+| `lib/feature-flags.ts` | Flag registry (phase-121..124, env resolution, rollback notes) |
+| `lib/gateway-health.ts` | Gateway latency scoring + dashboard snapshot (phase-121) |
+| `lib/offchain-delta.ts` | Off-chain delta store, hash/stub helpers (phase-122) |
+| `lib/ipfs-fallback.ts` / `lib/phase-nft-metadata-build.ts` | IPFS timeout fallback chain (phase-123) |
+| `lib/metadata-migration.ts` | Metadata version migration v1→v2 (phase-124) |
 | `contracts/` | Soroban Rust contracts and tooling docs |
 | `docs/` | Technical and operational documentation |
 
@@ -111,6 +116,15 @@ All handlers live in `app/api/**/route.ts`.
 - `forge-agent` and `claim-bounty` now use strict TypeScript response unions.
 - Error payloads are explicit and status-code aligned.
 - No untyped `any` responses should be used for public API contracts.
+
+### 5.3 Flag-gated API extensions
+
+| Flag | Route | Extension | Flag off |
+|------|-------|-----------|----------|
+| `phase-121` | `GET /api/phase-nft/custodian-release` | Gateway health dashboard: sorted gateway list with latency scoring (`score`, `avgLatencyMs`, `uptime`) | `404` disabled |
+| `phase-122` | `POST /api/phase-nft/verify` | Adds `delta` + `storage` fields (off-chain manifest, stub note) | Fields omitted |
+| `phase-123` | `GET /api/metadata/[id]` & `GET /api/ipfs/[...cid]` | Adds `X-Phase-*` headers, per-gateway timeout, structured `perGateway` error | Legacy 8s sequential, no headers |
+| `phase-124` | `scripts/*` | Migration logs, `--migrate-metadata` CLI | No-op with hint |
 
 ---
 
@@ -168,6 +182,21 @@ Critical groups:
 - Classic asset configuration (`CLASSIC_LIQ_*`, `NEXT_PUBLIC_CLASSIC_*`)
 - Gemini runtime (`GEMINI_API_KEY`)
 - Writable server data directory (`PHASE_SERVER_DATA_DIR`)
+
+### 9.1 Feature flags (phase-121..124)
+
+All flags default to **off** (safe rollback). Set to `1`/`true` to enable.
+
+```
+# Enable all four (example)
+NEXT_PUBLIC_FEATURE_PHASE_121=1
+NEXT_PUBLIC_FEATURE_PHASE_122=1
+NEXT_PUBLIC_FEATURE_PHASE_123=1
+NEXT_PUBLIC_FEATURE_PHASE_124=1
+# Server-only aliases also accepted: FEATURE_PHASE_121, etc.
+```
+
+Rollback: unset the var or set `0` and restart. No ledger migration to revert; off-chain stores remain but are ignored when flag off. See `PROJECT_ARCHITECTURE.md` §10.
 
 ---
 

--- a/lib/__tests__/gateway-health.test.ts
+++ b/lib/__tests__/gateway-health.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, beforeEach } from "node:test"
+import * as assert from "node:assert/strict"
+import { recordGatewayLatency, getGatewayHealthSnapshot, resetGatewayHealth } from "@/lib/gateway-health"
+
+describe("phase-121 gateway health", () => {
+  beforeEach(() => resetGatewayHealth())
+
+  it("scores fast gateway higher than slow", () => {
+    process.env.FEATURE_PHASE_121 = "1"
+    recordGatewayLatency("https://fast.test/ipfs", 120, true)
+    recordGatewayLatency("https://fast.test/ipfs", 130, true)
+    recordGatewayLatency("https://slow.test/ipfs", 4500, true)
+    recordGatewayLatency("https://slow.test/ipfs", 4800, true)
+    const snap = getGatewayHealthSnapshot()
+    const fast = snap.gateways.find((g) => g.gateway.includes("fast.test"))
+    const slow = snap.gateways.find((g) => g.gateway.includes("slow.test"))
+    assert.ok(fast)
+    assert.ok(slow)
+    assert.ok(fast!.score > slow!.score)
+    assert.ok(fast!.avgLatencyMs < slow!.avgLatencyMs)
+    process.env.FEATURE_PHASE_121 = ""
+  })
+
+  it("uptime affects score", () => {
+    process.env.FEATURE_PHASE_121 = "1"
+    recordGatewayLatency("https://flaky.test/ipfs", 200, true)
+    recordGatewayLatency("https://flaky.test/ipfs", 200, false)
+    recordGatewayLatency("https://flaky.test/ipfs", 200, false)
+    const snap = getGatewayHealthSnapshot()
+    const flaky = snap.gateways.find((g) => g.gateway.includes("flaky.test"))
+    assert.ok(flaky)
+    assert.ok(Math.abs(flaky!.uptime - 0.333) < 0.1)
+    assert.ok(flaky!.score < 70)
+    process.env.FEATURE_PHASE_121 = ""
+  })
+
+  it("snapshot is sorted by score", () => {
+    process.env.FEATURE_PHASE_121 = "1"
+    resetGatewayHealth()
+    recordGatewayLatency("https://a.test/ipfs", 100, true)
+    recordGatewayLatency("https://b.test/ipfs", 5000, true)
+    const snap = getGatewayHealthSnapshot()
+    const filtered = snap.gateways.filter((g) => g.totalRequests > 0)
+    assert.ok(filtered[0]!.score >= filtered[1]!.score)
+    process.env.FEATURE_PHASE_121 = ""
+  })
+})

--- a/lib/__tests__/ipfs-fallback.test.ts
+++ b/lib/__tests__/ipfs-fallback.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, beforeEach, mock } from "node:test"
+import * as assert from "node:assert/strict"
+import { fetchWithIpfsFallback, resolveIpfsFallbackConfig } from "@/lib/phase-nft-metadata-build"
+
+describe("phase-123 ipfs fallback", () => {
+  it("resolves config with defaults", () => {
+    const cfg = resolveIpfsFallbackConfig({})
+    assert.ok(cfg.gateways.length > 0)
+    assert.ok(cfg.timeoutMs >= 500)
+  })
+
+  it("validates empty ipfs path", async () => {
+    const res = await fetchWithIpfsFallback("", { config: { timeoutMs: 500 } })
+    assert.equal(res.ok, false)
+  })
+
+  it("falls back across gateways on failure", async () => {
+    const origFetch = global.fetch
+    let calls = 0
+    // @ts-ignore mock
+    global.fetch = async () => {
+      calls++
+      throw new Error("network fail")
+    }
+    const res = await fetchWithIpfsFallback("QmTest", { config: { gateways: ["https://a.test/ipfs", "https://b.test/ipfs"], timeoutMs: 200 } })
+    assert.equal(res.ok, false)
+    if (!res.ok) assert.equal(res.perGateway.length, 2)
+    assert.equal(calls, 2)
+    global.fetch = origFetch
+  })
+
+  it("returns first successful gateway", async () => {
+    const origFetch = global.fetch
+    // @ts-ignore mock
+    global.fetch = async (url: string | URL | Request) => {
+      if (String(url).includes("a.test")) throw new Error("fail")
+      return new Response(new ArrayBuffer(4), { status: 200, headers: { "content-type": "image/png" } })
+    }
+    const res = await fetchWithIpfsFallback("QmOk", { config: { gateways: ["https://a.test/ipfs", "https://b.test/ipfs"], timeoutMs: 500 } })
+    assert.equal(res.ok, true)
+    if (res.ok) assert.ok(res.gateway.includes("b.test"))
+    global.fetch = origFetch
+  })
+})

--- a/lib/__tests__/metadata-migration.test.ts
+++ b/lib/__tests__/metadata-migration.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from "node:test"
+import * as assert from "node:assert/strict"
+import { migrateMetadataPayload, batchMigrateMetadataPayloads, CURRENT_METADATA_VERSION } from "@/lib/metadata-migration"
+
+describe("phase-124 metadata migration", () => {
+  const OLD_V1 = { name: "Test", description: "Old", image: "ipfs://Qm123" }
+  const V2 = { version: 2 as const, name: "Test", description: "New", image: "ipfs://Qm123", external_url: "", attributes: [], collectionId: null }
+
+  it("migrates v1 -> v2 with force flag", () => {
+    const res = migrateMetadataPayload(OLD_V1, { force: true })
+    assert.equal(res.ok, true)
+    if (res.ok) {
+      assert.equal(res.version, 2)
+      assert.equal(res.migrated, true)
+      assert.equal(res.data.version, CURRENT_METADATA_VERSION)
+      assert.equal(res.data.name, "Test")
+    }
+  })
+
+  it("passes through v2 unchanged", () => {
+    const res = migrateMetadataPayload(V2, { force: true })
+    assert.equal(res.ok, true)
+    if (res.ok) assert.equal(res.migrated, false)
+  })
+
+  it("fails when flag disabled without force", () => {
+    const res = migrateMetadataPayload(OLD_V1, {})
+    if (process.env.FEATURE_PHASE_124 !== "1" && process.env.NEXT_PUBLIC_FEATURE_PHASE_124 !== "1") {
+      assert.equal(res.ok, false)
+      if (!res.ok) assert.equal(res.error.code, "FLAG_DISABLED")
+    }
+  })
+
+  it("batch migrates", () => {
+    const report = batchMigrateMetadataPayloads([OLD_V1, V2], { force: true })
+    assert.equal(report.total, 2)
+    assert.equal(report.migrated, 1)
+    assert.equal(report.alreadyCurrent, 1)
+    assert.equal(report.failed, 0)
+  })
+
+  it("validates invalid payload", () => {
+    const res = migrateMetadataPayload({ name: "" }, { force: true })
+    assert.equal(res.ok, false)
+  })
+})

--- a/lib/__tests__/offchain-delta.test.ts
+++ b/lib/__tests__/offchain-delta.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, beforeEach } from "node:test"
+import * as assert from "node:assert/strict"
+import { computeDeltaHash, buildOnChainStub, parseOnChainStub, storeOffchainDelta, fetchOffchainDelta, clearDeltaMemoryStore } from "@/lib/offchain-delta"
+
+describe("phase-122 off-chain delta", () => {
+  beforeEach(() => {
+    clearDeltaMemoryStore()
+    process.env.FEATURE_PHASE_122 = "1"
+  })
+
+  it("hash is deterministic", () => {
+    const payload = { name: "Test", image: "ipfs://..." }
+    const h1 = computeDeltaHash(payload)
+    const h2 = computeDeltaHash(payload)
+    assert.equal(h1, h2)
+    assert.equal(h1.length, 64)
+  })
+
+  it("stub round-trips", () => {
+    const stub = buildOnChainStub(42, "a".repeat(64))
+    assert.equal(stub, "delta:42:aaaaaaaa")
+    const parsed = parseOnChainStub(stub)
+    assert.equal(parsed?.tokenId, 42)
+    assert.equal(parsed?.hashPrefix, "aaaaaaaa")
+  })
+
+  it("rejects invalid stub", () => {
+    assert.equal(parseOnChainStub("delta:0:abc"), null)
+    assert.equal(parseOnChainStub("not-a-stub"), null)
+  })
+
+  it("stores and fetches delta", async () => {
+    const contractId = "C" + "A".repeat(55)
+    const tokenId = 7
+    const payload = { name: "Artifact #7", description: "Large metadata..." }
+    const stored = await storeOffchainDelta(contractId, tokenId, payload)
+    assert.equal(stored.ok, true)
+    if (stored.ok) assert.equal(stored.hash.length, 64)
+    const fetched = await fetchOffchainDelta(contractId, tokenId)
+    assert.equal(fetched.ok, true)
+    if (fetched.ok) assert.deepEqual(fetched.data, payload)
+  })
+
+  it("detects hash mismatch", async () => {
+    const contractId = "C" + "B".repeat(55)
+    await storeOffchainDelta(contractId, 1, { a: 1 })
+    const res = await fetchOffchainDelta(contractId, 1, { expectedHash: "f".repeat(64) })
+    assert.equal(res.ok, false)
+    if (!res.ok) assert.equal(res.code, "HASH_MISMATCH")
+  })
+
+  it("respects flag disabled", async () => {
+    process.env.FEATURE_PHASE_122 = "0"
+    const res = await storeOffchainDelta("C" + "A".repeat(55), 1, {})
+    assert.equal(res.ok, false)
+    if (!res.ok) assert.equal(res.code, "FLAG_DISABLED")
+    process.env.FEATURE_PHASE_122 = "1"
+  })
+})

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,50 @@
+/**
+ * Feature flags — PHASE rolling delivery.
+ *
+ * Each flag is opt-in via env. Supports both server and client where needed.
+ * Rollback: unset the env var or set to "0"/"false" and restart. No migration to undo.
+ *
+ * Flags:
+ * - phase-121: gateway health dashboard with latency scoring
+ * - phase-122: off-chain metadata delta storage
+ * - phase-123: IPFS timeout fallback chain
+ * - phase-124: metadata version migration tool
+ */
+
+export type PhaseFeatureFlag = "phase-121" | "phase-122" | "phase-123" | "phase-124"
+
+const FLAG_ENV_MAP: Record<PhaseFeatureFlag, string[]> = {
+  "phase-121": ["NEXT_PUBLIC_FEATURE_PHASE_121", "FEATURE_PHASE_121"],
+  "phase-122": ["NEXT_PUBLIC_FEATURE_PHASE_122", "FEATURE_PHASE_122"],
+  "phase-123": ["NEXT_PUBLIC_FEATURE_PHASE_123", "FEATURE_PHASE_123"],
+  "phase-124": ["NEXT_PUBLIC_FEATURE_PHASE_124", "FEATURE_PHASE_124"],
+}
+
+function isTruthy(v: string | undefined): boolean {
+  if (!v) return false
+  const s = v.trim().toLowerCase()
+  return s === "1" || s === "true" || s === "yes" || s === "on"
+}
+
+export function isFeatureEnabled(flag: PhaseFeatureFlag): boolean {
+  const keys = FLAG_ENV_MAP[flag]
+  for (const k of keys) {
+    const v = (typeof process !== "undefined" ? (process.env as Record<string, string | undefined>)[k] : undefined)
+    if (isTruthy(v)) return true
+  }
+  return false
+}
+
+export function featureFlagEnvKeys(flag: PhaseFeatureFlag): string[] {
+  return [...FLAG_ENV_MAP[flag]]
+}
+
+export function getEnabledFeatureFlags(): PhaseFeatureFlag[] {
+  const all: PhaseFeatureFlag[] = ["phase-121", "phase-122", "phase-123", "phase-124"]
+  return all.filter(isFeatureEnabled)
+}
+
+export function flagRollbackNote(flag: PhaseFeatureFlag): string {
+  const keys = FLAG_ENV_MAP[flag].join(" / ")
+  return `Rollback ${flag}: unset ${keys} or set to 0/false and restart. No data migration to revert.`
+}

--- a/lib/gateway-health.ts
+++ b/lib/gateway-health.ts
@@ -1,0 +1,174 @@
+/**
+ * Gateway health dashboard with latency scoring — phase-121
+ *
+ * Operators cannot see which gateway is slow. This module provides
+ * per-gateway latency tracking, scoring, and a dashboard payload.
+ *
+ * Feature flag: phase-121 (NEXT_PUBLIC_FEATURE_PHASE_121 / FEATURE_PHASE_121)
+ * Rollback: unset flag → dashboard route returns 404/disabled, protocol falls back
+ *           to static gateway list. No persistent state to revert.
+ */
+
+import { z } from "zod"
+import { isFeatureEnabled } from "@/lib/feature-flags"
+
+export const GatewayHealthEntrySchema = z.object({
+  gateway: z.string().url(),
+  totalRequests: z.number().int().min(0),
+  successCount: z.number().int().min(0),
+  failCount: z.number().int().min(0),
+  avgLatencyMs: z.number().min(0),
+  p95LatencyMs: z.number().min(0),
+  lastLatencyMs: z.number().min(0),
+  lastStatus: z.enum(["ok", "fail", "unknown"]),
+  lastCheckedAt: z.string().datetime().nullable(),
+  score: z.number().min(0).max(100),
+  uptime: z.number().min(0).max(1),
+})
+
+export type GatewayHealthEntry = z.infer<typeof GatewayHealthEntrySchema>
+
+export type GatewayHealthSnapshot = {
+  enabled: boolean
+  updatedAt: string
+  gateways: GatewayHealthEntry[]
+  bestGateway: string | null
+  worstGateway: string | null
+}
+
+type InternalSample = { latencyMs: number; ok: boolean; at: number }
+
+const MAX_SAMPLES_PER_GATEWAY = 50
+const SCORE_LATENCY_WEIGHT = 0.6
+const SCORE_UPTIME_WEIGHT = 0.4
+
+// In-memory store (per-process). For multi-instance, this is best-effort; durable
+// persistence can be added via PHASE_SERVER_DATA_DIR if needed.
+const samples = new Map<string, InternalSample[]>()
+const lastStatus = new Map<string, { ok: boolean; latencyMs: number; at: number }>()
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0
+  const idx = Math.ceil((p / 100) * sorted.length) - 1
+  return sorted[Math.max(0, Math.min(idx, sorted.length - 1))] ?? 0
+}
+
+function scoreFor(latencies: number[], uptime: number): number {
+  if (latencies.length === 0) return 50
+  const avg = latencies.reduce((a, b) => a + b, 0) / latencies.length
+  // Map avg latency to 0-100: 0ms=100, 500ms=80, 2000ms=40, 5000ms=10, 8000ms=0
+  let latencyScore: number
+  if (avg <= 200) latencyScore = 100 - (avg / 200) * 10 // 90-100
+  else if (avg <= 1000) latencyScore = 90 - ((avg - 200) / 800) * 30 // 60-90
+  else if (avg <= 4000) latencyScore = 60 - ((avg - 1000) / 3000) * 40 // 20-60
+  else latencyScore = Math.max(0, 20 - ((avg - 4000) / 4000) * 20) // 0-20
+
+  const uptimeScore = uptime * 100
+  const raw = latencyScore * SCORE_LATENCY_WEIGHT + uptimeScore * SCORE_UPTIME_WEIGHT
+  return Math.max(0, Math.min(100, Math.round(raw)))
+}
+
+function normalizeGateway(gateway: string): string {
+  return gateway.trim().replace(/\/+$/, "")
+}
+
+export function recordGatewayLatency(gateway: string, latencyMs: number, ok: boolean): void {
+  if (!isFeatureEnabled("phase-121") && process.env.NODE_ENV !== "test") {
+    // Still record in test; otherwise no-op when flag off to avoid overhead
+    return
+  }
+  const key = normalizeGateway(gateway)
+  const list = samples.get(key) ?? []
+  list.push({ latencyMs: Math.max(0, latencyMs), ok, at: Date.now() })
+  if (list.length > MAX_SAMPLES_PER_GATEWAY) list.shift()
+  samples.set(key, list)
+  lastStatus.set(key, { ok, latencyMs, at: Date.now() })
+}
+
+export function getGatewayHealthSnapshot(): GatewayHealthSnapshot {
+  const enabled = isFeatureEnabled("phase-121")
+  const entries: GatewayHealthEntry[] = []
+
+  for (const [gateway, list] of samples.entries()) {
+    const totalRequests = list.length
+    const successCount = list.filter((s) => s.ok).length
+    const failCount = totalRequests - successCount
+    const uptime = totalRequests > 0 ? successCount / totalRequests : 0
+    const latencies = list.filter((s) => s.ok).map((s) => s.latencyMs).sort((a, b) => a - b)
+    const avgLatencyMs = latencies.length > 0 ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0
+    const p95LatencyMs = Math.round(percentile(latencies, 95))
+    const last = lastStatus.get(gateway)
+    const score = scoreFor(latencies, uptime)
+
+    entries.push({
+      gateway,
+      totalRequests,
+      successCount,
+      failCount,
+      avgLatencyMs,
+      p95LatencyMs,
+      lastLatencyMs: last?.latencyMs ?? 0,
+      lastStatus: last ? (last.ok ? "ok" : "fail") : "unknown",
+      lastCheckedAt: last ? new Date(last.at).toISOString() : null,
+      score,
+      uptime: Math.round(uptime * 1000) / 1000,
+    })
+  }
+
+  // Also include known default gateways even if no samples yet (score 50, unknown)
+  const { DEFAULT_IPFS_GATEWAYS } = (() => {
+    try {
+      // Avoid circular import; hardcode fallback
+      return { DEFAULT_IPFS_GATEWAYS: ["https://w3s.link/ipfs", "https://dweb.link/ipfs", "https://ipfs.io/ipfs", "https://cloudflare-ipfs.com/ipfs"] as const }
+    } catch {
+      return { DEFAULT_IPFS_GATEWAYS: [] as const }
+    }
+  })()
+  for (const g of DEFAULT_IPFS_GATEWAYS as readonly string[]) {
+    if (!samples.has(g)) {
+      entries.push({
+        gateway: g,
+        totalRequests: 0,
+        successCount: 0,
+        failCount: 0,
+        avgLatencyMs: 0,
+        p95LatencyMs: 0,
+        lastLatencyMs: 0,
+        lastStatus: "unknown",
+        lastCheckedAt: null,
+        score: 50,
+        uptime: 0,
+      })
+    }
+  }
+
+  entries.sort((a, b) => b.score - a.score)
+
+  return {
+    enabled,
+    updatedAt: new Date().toISOString(),
+    gateways: entries,
+    bestGateway: entries[0]?.gateway ?? null,
+    worstGateway: entries.length > 0 ? entries[entries.length - 1]!.gateway : null,
+  }
+}
+
+export function getGatewayRanking(): string[] {
+  return getGatewayHealthSnapshot().gateways
+    .filter((g) => g.lastStatus !== "unknown" || g.totalRequests > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((g) => g.gateway)
+}
+
+export function resetGatewayHealth(): void {
+  samples.clear()
+  lastStatus.clear()
+}
+
+// Validation for API query
+export const GatewayHealthQuerySchema = z.object({
+  sort: z.enum(["score", "latency", "uptime"]).optional().default("score"),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(20),
+})
+
+export type GatewayHealthQuery = z.infer<typeof GatewayHealthQuerySchema>

--- a/lib/ipfs-fallback.ts
+++ b/lib/ipfs-fallback.ts
@@ -1,0 +1,198 @@
+/**
+ * IPFS timeout fallback chain — phase-123
+ *
+ * One slow gateway stalls the whole read. This module provides a timeout-aware
+ * fallback chain across providers with structured errors and per-gateway latency
+ * tracking (consumed by gateway-health when phase-121 is enabled).
+ *
+ * Feature flag: phase-123 (NEXT_PUBLIC_FEATURE_PHASE_123 / FEATURE_PHASE_123)
+ * Rollback: unset flag → falls back to legacy single-timeout sequential loop.
+ *
+ * Providers default to PHASE IPFS gateways; override via NEXT_PUBLIC_PHASE_IPFS_GATEWAYS (comma-separated).
+ */
+
+import { z } from "zod"
+import { isFeatureEnabled } from "@/lib/feature-flags"
+
+export const DEFAULT_IPFS_GATEWAYS = [
+  "https://w3s.link/ipfs",
+  "https://dweb.link/ipfs",
+  "https://ipfs.io/ipfs",
+  "https://cloudflare-ipfs.com/ipfs",
+] as const
+
+export const IpfsFallbackConfigSchema = z.object({
+  gateways: z.array(z.string().url()).min(1).max(8),
+  timeoutMs: z.number().int().min(500).max(30000),
+  retriesPerGateway: z.number().int().min(0).max(2).default(0),
+  concurrency: z.number().int().min(1).max(4).default(1),
+})
+
+export type IpfsFallbackConfig = z.infer<typeof IpfsFallbackConfigSchema>
+
+export type IpfsFetchResult =
+  | { ok: true; gateway: string; bytes: ArrayBuffer; contentType: string; latencyMs: number; attempts: number }
+  | { ok: false; error: string; attempts: number; perGateway: Array<{ gateway: string; error: string; latencyMs: number }> }
+
+export type IpfsFetchOptions = {
+  config?: Partial<IpfsFallbackConfig>
+  signal?: AbortSignal
+  headers?: Record<string, string>
+}
+
+function parseEnvGateways(): string[] | null {
+  const raw = (typeof process !== "undefined" ? process.env.NEXT_PUBLIC_PHASE_IPFS_GATEWAYS?.trim() : "") ?? ""
+  if (!raw) return null
+  const parts = raw
+    .split(/[,\s]+/)
+    .map((s) => s.trim().replace(/\/+$/, ""))
+    .filter((s) => /^https?:\/\//i.test(s))
+    .map((s) => (s.endsWith("/ipfs") ? s : `${s}/ipfs`))
+  return parts.length > 0 ? parts : null
+}
+
+export function resolveIpfsFallbackConfig(overrides: Partial<IpfsFallbackConfig> = {}): IpfsFallbackConfig {
+  const envGateways = parseEnvGateways()
+  const gateways = overrides.gateways ?? envGateways ?? [...DEFAULT_IPFS_GATEWAYS]
+  const timeoutMs = overrides.timeoutMs ?? (isFeatureEnabled("phase-123") ? 4000 : 8000)
+  const retriesPerGateway = overrides.retriesPerGateway ?? 0
+  const concurrency = overrides.concurrency ?? 1
+
+  const parsed = IpfsFallbackConfigSchema.safeParse({ gateways, timeoutMs, retriesPerGateway, concurrency })
+  if (!parsed.success) {
+    // Fallback to safe defaults on validation failure
+    return { gateways: [...DEFAULT_IPFS_GATEWAYS], timeoutMs: 4000, retriesPerGateway: 0, concurrency: 1 }
+  }
+  return parsed.data
+}
+
+function withTimeout(signal: AbortSignal | undefined, ms: number): { signal: AbortSignal; cancel: () => void } {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(new DOMException(`Timeout after ${ms}ms`, "TimeoutError")), ms)
+  const cancel = () => clearTimeout(timer)
+  if (signal) {
+    if (signal.aborted) controller.abort(signal.reason)
+    else signal.addEventListener("abort", () => controller.abort(signal.reason), { once: true })
+  }
+  return { signal: controller.signal, cancel }
+}
+
+export async function fetchIpfsWithFallback(
+  ipfsPath: string,
+  opts: IpfsFetchOptions = {},
+): Promise<IpfsFetchResult> {
+  const cleanPath = ipfsPath.replace(/^\/+/, "").trim()
+  if (!cleanPath) {
+    return { ok: false, error: "Empty IPFS path", attempts: 0, perGateway: [] }
+  }
+
+  const config = resolveIpfsFallbackConfig(opts.config)
+  const perGateway: Array<{ gateway: string; error: string; latencyMs: number }> = []
+  let attempts = 0
+
+  // Sequential fallback (concurrency=1) ensures one slow gateway doesn't block parallel burst.
+  // When concurrency>1 is configured, we race a window of gateways.
+  if (config.concurrency === 1) {
+    for (const base of config.gateways) {
+      const url = `${base.replace(/\/+$/, "")}/${cleanPath}`
+      let gatewayAttempts = 0
+      while (gatewayAttempts <= config.retriesPerGateway) {
+        gatewayAttempts++
+        attempts++
+        const start = Date.now()
+        const { signal, cancel } = withTimeout(opts.signal, config.timeoutMs)
+        try {
+          const res = await fetch(url, { signal, headers: { Accept: "*/*", ...(opts.headers ?? {}) }, cache: "no-store" as RequestCache })
+          cancel()
+          const latencyMs = Date.now() - start
+          if (!res.ok) {
+            perGateway.push({ gateway: base, error: `HTTP ${res.status}`, latencyMs })
+            break // try next gateway
+          }
+          const contentType = res.headers.get("content-type") ?? "application/octet-stream"
+          const bytes = await res.arrayBuffer()
+          // Optional hook for gateway-health (best-effort dynamic import to avoid circular dep)
+          try {
+            const mod = await import("@/lib/gateway-health").catch(() => null)
+            if (mod && typeof mod.recordGatewayLatency === "function") {
+              mod.recordGatewayLatency(base, latencyMs, true)
+            }
+          } catch { /* ignore */ }
+          return { ok: true, gateway: base, bytes, contentType, latencyMs, attempts }
+        } catch (e) {
+          cancel()
+          const latencyMs = Date.now() - start
+          const msg = e instanceof Error ? e.message : String(e)
+          const isTimeout = msg.toLowerCase().includes("timeout") || (e as DOMException)?.name === "TimeoutError"
+          perGateway.push({ gateway: base, error: isTimeout ? `timeout@${config.timeoutMs}ms` : msg.slice(0, 200), latencyMs })
+          try {
+            const mod = await import("@/lib/gateway-health").catch(() => null)
+            if (mod && typeof mod.recordGatewayLatency === "function") {
+              mod.recordGatewayLatency(base, latencyMs, false)
+            }
+          } catch { /* ignore */ }
+          if (opts.signal?.aborted) {
+            return { ok: false, error: `Aborted: ${msg}`, attempts, perGateway }
+          }
+          // retry same gateway if retries left, else move to next
+          if (gatewayAttempts <= config.retriesPerGateway) continue
+          break
+        }
+      }
+    }
+    return { ok: false, error: "All IPFS gateways failed or timed out", attempts, perGateway }
+  }
+
+  // Concurrent window fallback (phase-123 enabled advanced path)
+  // Race N gateways at a time; as soon as one succeeds, abort others.
+  for (let i = 0; i < config.gateways.length; i += config.concurrency) {
+    const window = config.gateways.slice(i, i + config.concurrency)
+    const ac = new AbortController()
+    if (opts.signal) {
+      const sig = opts.signal
+      if (sig.aborted) ac.abort((sig as AbortSignal & { reason?: unknown }).reason)
+      else sig.addEventListener("abort", () => ac.abort((sig as AbortSignal & { reason?: unknown }).reason), { once: true })
+    }
+
+    const results = await Promise.all(
+      window.map(async (base) => {
+        const url = `${base.replace(/\/+$/, "")}/${cleanPath}`
+        const start = Date.now()
+        attempts++
+        const { signal, cancel } = withTimeout(ac.signal, config.timeoutMs)
+        try {
+          const res = await fetch(url, { signal, headers: { Accept: "*/*", ...(opts.headers ?? {}) }, cache: "no-store" as RequestCache })
+          cancel()
+          const latencyMs = Date.now() - start
+          if (!res.ok) {
+            perGateway.push({ gateway: base, error: `HTTP ${res.status}`, latencyMs })
+            return null
+          }
+          const contentType = res.headers.get("content-type") ?? "application/octet-stream"
+          const bytes = await res.arrayBuffer()
+          return { gateway: base, bytes, contentType, latencyMs } as const
+        } catch (e) {
+          cancel()
+          const latencyMs = Date.now() - start
+          const msg = e instanceof Error ? e.message : String(e)
+          perGateway.push({ gateway: base, error: msg.slice(0, 200), latencyMs })
+          return null
+        }
+      }),
+    )
+    const winner = results.find((r): r is NonNullable<typeof r> => r != null)
+    if (winner) {
+      ac.abort(new DOMException("Winner found", "AbortError"))
+      return { ok: true, ...winner, attempts }
+    }
+  }
+
+  return { ok: false, error: "All IPFS gateways failed or timed out (concurrent)", attempts, perGateway }
+}
+
+// Convenience: validate ipfsPath
+export const IpfsPathSchema = z.string().min(4).max(512).regex(/^[A-Za-z0-9._\/-]+$/, "Invalid IPFS path characters")
+
+export function isIpfsFallbackEnabled(): boolean {
+  return isFeatureEnabled("phase-123")
+}

--- a/lib/metadata-migration.ts
+++ b/lib/metadata-migration.ts
@@ -1,0 +1,242 @@
+/**
+ * Metadata version migration tool — phase-124
+ *
+ * Handles schema changes for off-chain JSON metadata kept in `.data/` and
+ * public/static metadata. Old formats become incompatible on upgrade; this
+ * module provides versioned schemas, validation, and safe migration.
+ *
+ * Feature flag: phase-124 (NEXT_PUBLIC_FEATURE_PHASE_124 / FEATURE_PHASE_124)
+ * Rollback: disable flag and restart; v2 payloads remain readable by v1 consumers
+ *           where fields are additive. No destructive rewrite without --apply.
+ *
+ * Usage (scripts):
+ *   import { migrateMetadataPayload, CURRENT_METADATA_VERSION } from "@/lib/metadata-migration"
+ *   const result = migrateMetadataPayload(raw, { dryRun: true })
+ */
+
+import { z } from "zod"
+import { isFeatureEnabled } from "@/lib/feature-flags"
+
+// ── Versioning ──────────────────────────────────────────────────────────
+
+export const CURRENT_METADATA_VERSION = 2 as const
+export type MetadataVersion = 1 | 2
+
+export const MetadataVersionSchema = z.union([z.literal(1), z.literal(2)])
+
+// ── Schemas ─────────────────────────────────────────────────────────────
+
+export const NftMetadataV1Schema = z.object({
+  version: z.literal(1).optional(),
+  name: z.string().min(1).max(256),
+  description: z.string().max(2048).optional().default(""),
+  image: z.string().max(1024).optional().default(""),
+  attributes: z
+    .array(z.object({ trait_type: z.string(), value: z.union([z.string(), z.number()]) }))
+    .optional()
+    .default([]),
+})
+
+export const NftMetadataV2Schema = z.object({
+  version: z.literal(2),
+  name: z.string().min(1).max(256),
+  description: z.string().max(2048),
+  image: z.string().max(1024),
+  external_url: z.string().url().or(z.string().length(0)).optional().default(""),
+  attributes: z.array(
+    z.object({
+      trait_type: z.string().min(1).max(64),
+      value: z.union([z.string(), z.number()]),
+      display_type: z.enum(["number", "date", "boost_percentage"]).optional(),
+    }),
+  ),
+  collectionId: z.number().int().min(0).nullable().default(null),
+  migratedAt: z.string().datetime().optional(),
+  migratedFrom: z.union([z.literal(1), z.literal(2)]).optional(),
+})
+
+export type NftMetadataV1 = z.infer<typeof NftMetadataV1Schema>
+export type NftMetadataV2 = z.infer<typeof NftMetadataV2Schema>
+
+// Alias for current
+export const CurrentMetadataSchema = NftMetadataV2Schema
+export type CurrentMetadata = NftMetadataV2
+
+// ── Structured errors ───────────────────────────────────────────────────
+
+export type MigrationErrorCode =
+  | "VALIDATION_FAILED"
+  | "UNSUPPORTED_VERSION"
+  | "MIGRATION_FAILED"
+  | "FLAG_DISABLED"
+
+export class MetadataMigrationError extends Error {
+  code: MigrationErrorCode
+  details?: unknown
+  constructor(code: MigrationErrorCode, message: string, details?: unknown) {
+    super(message)
+    this.name = "MetadataMigrationError"
+    this.code = code
+    this.details = details
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function detectVersion(raw: unknown): MetadataVersion | null {
+  if (raw && typeof raw === "object" && "version" in raw) {
+    const v = (raw as { version?: unknown }).version
+    if (v === 1 || v === 2) return v
+    if (v === "1" || v === "2") return Number(v) as MetadataVersion
+  }
+  // No version field → treat as v1 (legacy)
+  if (raw && typeof raw === "object" && "name" in raw) return 1
+  return null
+}
+
+function migrateV1ToV2(v1: NftMetadataV1, opts?: { baseUrl?: string }): NftMetadataV2 {
+  const normalizedAttrs = (v1.attributes ?? []).map((a) => ({
+    trait_type: String(a.trait_type).trim().slice(0, 64) || "unknown",
+    value: a.value,
+  }))
+  return {
+    version: 2,
+    name: v1.name.trim(),
+    description: (v1.description ?? "").trim(),
+    image: (v1.image ?? "").trim(),
+    external_url: opts?.baseUrl ?? "",
+    attributes: normalizedAttrs as NftMetadataV2["attributes"],
+    collectionId: null,
+    migratedAt: new Date().toISOString(),
+    migratedFrom: 1,
+  }
+}
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export type MigrateOptions = {
+  dryRun?: boolean
+  baseUrl?: string
+  strict?: boolean
+  /** Override flag check (useful in tests / scripts with explicit opt-in) */
+  force?: boolean
+}
+
+export type MigrateResult =
+  | { ok: true; version: MetadataVersion; data: CurrentMetadata; migrated: boolean; fromVersion: MetadataVersion }
+  | { ok: false; error: MetadataMigrationError }
+
+export function migrateMetadataPayload(raw: unknown, opts: MigrateOptions = {}): MigrateResult {
+  const flagEnabled = opts.force || isFeatureEnabled("phase-124")
+  if (!flagEnabled) {
+    return {
+      ok: false,
+      error: new MetadataMigrationError("FLAG_DISABLED", "Metadata migration is disabled (phase-124 flag off). Enable NEXT_PUBLIC_FEATURE_PHASE_124=1 to use."),
+    }
+  }
+
+  const detected = detectVersion(raw)
+  if (detected == null) {
+    return {
+      ok: false,
+      error: new MetadataMigrationError("UNSUPPORTED_VERSION", "Cannot detect metadata version; payload missing `name` or `version`.", { raw: typeof raw === "object" ? Object.keys(raw as object) : typeof raw }),
+    }
+  }
+
+  try {
+    if (detected === 2) {
+      const parsed = NftMetadataV2Schema.safeParse(raw)
+      if (!parsed.success) {
+        if (opts.strict) {
+          return { ok: false, error: new MetadataMigrationError("VALIDATION_FAILED", parsed.error.message, parsed.error.flatten()) }
+        }
+        // Attempt to recover by migrating through v1 shape
+        const v1Fallback = NftMetadataV1Schema.safeParse(raw)
+        if (!v1Fallback.success) {
+          return { ok: false, error: new MetadataMigrationError("VALIDATION_FAILED", parsed.error.message, parsed.error.flatten()) }
+        }
+        const v2 = migrateV1ToV2(v1Fallback.data, { baseUrl: opts.baseUrl })
+        return { ok: true, version: 2, data: v2, migrated: true, fromVersion: 1 }
+      }
+      return { ok: true, version: 2, data: parsed.data, migrated: false, fromVersion: 2 }
+    }
+
+    // v1 → v2
+    const parsedV1 = NftMetadataV1Schema.safeParse(raw)
+    if (!parsedV1.success) {
+      return { ok: false, error: new MetadataMigrationError("VALIDATION_FAILED", parsedV1.error.message, parsedV1.error.flatten()) }
+    }
+    const migrated = migrateV1ToV2(parsedV1.data, { baseUrl: opts.baseUrl })
+    const final = NftMetadataV2Schema.safeParse(migrated)
+    if (!final.success) {
+      return { ok: false, error: new MetadataMigrationError("MIGRATION_FAILED", final.error.message, final.error.flatten()) }
+    }
+    if (opts.dryRun) {
+      // Do not mutate caller's storage; just report what would happen
+      return { ok: true, version: 2, data: final.data, migrated: true, fromVersion: 1 }
+    }
+    return { ok: true, version: 2, data: final.data, migrated: true, fromVersion: 1 }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return { ok: false, error: new MetadataMigrationError("MIGRATION_FAILED", msg, e) }
+  }
+}
+
+export function validateCurrentMetadata(raw: unknown): { ok: true; data: CurrentMetadata } | { ok: false; error: z.ZodError } {
+  const parsed = CurrentMetadataSchema.safeParse(raw)
+  if (parsed.success) return { ok: true, data: parsed.data }
+  return { ok: false, error: parsed.error }
+}
+
+export function isCurrentVersion(raw: unknown): boolean {
+  return detectVersion(raw) === CURRENT_METADATA_VERSION && validateCurrentMetadata(raw).ok
+}
+
+// ── Batch/file helpers (for scripts) ────────────────────────────────────
+
+export type BatchMigrateReport = {
+  total: number
+  migrated: number
+  alreadyCurrent: number
+  failed: number
+  failures: Array<{ index: number; error: string; code: MigrationErrorCode }>
+  results: CurrentMetadata[]
+}
+
+export function batchMigrateMetadataPayloads(payloads: unknown[], opts: MigrateOptions = {}): BatchMigrateReport {
+  const report: BatchMigrateReport = { total: payloads.length, migrated: 0, alreadyCurrent: 0, failed: 0, failures: [], results: [] }
+  payloads.forEach((raw, i) => {
+    const res = migrateMetadataPayload(raw, opts)
+    if (!res.ok) {
+      report.failed++
+      report.failures.push({ index: i, error: res.error.message, code: res.error.code })
+      return
+    }
+    report.results.push(res.data)
+    if (res.migrated) report.migrated++
+    else report.alreadyCurrent++
+  })
+  return report
+}
+
+/** Convenience for scripts: migrate a single JSON file's parsed content. */
+export function migrateMetadataFileContent(fileContent: string, opts: MigrateOptions = {}): MigrateResult {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(fileContent)
+  } catch (e) {
+    return { ok: false, error: new MetadataMigrationError("VALIDATION_FAILED", `Invalid JSON: ${e instanceof Error ? e.message : String(e)}`) }
+  }
+  if (Array.isArray(parsed)) {
+    // If file is an array, migrate each element and return first as representative; callers should use batch helper.
+    const report = batchMigrateMetadataPayloads(parsed, opts)
+    if (report.failed > 0) {
+      return { ok: false, error: new MetadataMigrationError("MIGRATION_FAILED", `${report.failed}/${report.total} items failed`, report.failures) }
+    }
+    // Return aggregate success: version 2 shape with embedded results
+    const first = report.results[0]
+    if (!first) return { ok: false, error: new MetadataMigrationError("VALIDATION_FAILED", "Empty array") }
+    return { ok: true, version: 2, data: first, migrated: report.migrated > 0, fromVersion: report.migrated > 0 ? 1 : 2 }
+  }
+  return migrateMetadataPayload(parsed, opts)
+}

--- a/lib/offchain-delta.ts
+++ b/lib/offchain-delta.ts
@@ -1,0 +1,210 @@
+/**
+ * Off-chain metadata delta storage — phase-122
+ *
+ * Large metadata inflates contract storage rent. This module keeps the full
+ * metadata off-chain (JSON sidecar) and stores only a content hash + delta
+ * pointer on-chain. The on-chain size is reduced to 32 bytes (hash) + 8 bytes
+ * (version) + URI stub, while the full JSON lives in PHASE_SERVER_DATA_DIR
+ * or IPFS.
+ *
+ * Feature flag: phase-122 (NEXT_PUBLIC_FEATURE_PHASE_122 / FEATURE_PHASE_122)
+ * Rollback: disable flag → verify route falls back to on-chain token_uri only.
+ *           Off-chain files remain on disk; no ledger change to revert.
+ */
+
+import { createHash } from "node:crypto"
+import { z } from "zod"
+import { isFeatureEnabled } from "@/lib/feature-flags"
+
+export const OffchainDeltaManifestSchema = z.object({
+  version: z.literal(1),
+  tokenId: z.number().int().min(1),
+  contractId: z.string().min(56).max(56),
+  contentHash: z.string().regex(/^[a-f0-9]{64}$/, "expected sha256 hex"),
+  deltaRefs: z.array(z.string().max(256)).default([]),
+  storedAt: z.string().datetime(),
+  byteSize: z.number().int().min(0),
+  onChainStub: z.string().max(256),
+})
+
+export type OffchainDeltaManifest = z.infer<typeof OffchainDeltaManifestSchema>
+
+export type DeltaStoreResult =
+  | { ok: true; manifest: OffchainDeltaManifest; hash: string }
+  | { ok: false; error: string; code: "FLAG_DISABLED" | "VALIDATION_FAILED" | "STORE_FAILED" }
+
+export type DeltaFetchResult =
+  | { ok: true; data: unknown; manifest: OffchainDeltaManifest }
+  | { ok: false; error: string; code: "FLAG_DISABLED" | "NOT_FOUND" | "HASH_MISMATCH" | "VALIDATION_FAILED" }
+
+function sha256Hex(input: string | Buffer): string {
+  return createHash("sha256").update(input).digest("hex")
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_, v) => (typeof v === "bigint" ? v.toString() : v))
+}
+
+export function computeDeltaHash(payload: unknown): string {
+  return sha256Hex(stableStringify(payload))
+}
+
+export function buildOnChainStub(tokenId: number, contentHash: string): string {
+  // On-chain footprint: "delta:{tokenId}:{hash8}" ~ 20 chars instead of full JSON
+  return `delta:${tokenId}:${contentHash.slice(0, 8)}`
+}
+
+export function parseOnChainStub(stub: string): { tokenId: number; hashPrefix: string } | null {
+  const m = stub.match(/^delta:(\d+):([a-f0-9]{8})$/)
+  if (!m) return null
+  const tokenId = parseInt(m[1]!, 10)
+  if (!Number.isFinite(tokenId) || tokenId <= 0) return null
+  return { tokenId, hashPrefix: m[2]! }
+}
+
+// In-memory + optional file persistence (lazy import to avoid bundling fs in client)
+const memoryStore = new Map<string, { manifest: OffchainDeltaManifest; payload: unknown }>()
+
+function deltaKey(contractId: string, tokenId: number): string {
+  return `${contractId}:${tokenId}`
+}
+
+function ensureFlagOrFail(): DeltaStoreResult | null {
+  if (!isFeatureEnabled("phase-122")) {
+    return { ok: false, error: "Off-chain delta storage is disabled (phase-122 flag off).", code: "FLAG_DISABLED" }
+  }
+  return null
+}
+
+export async function storeOffchainDelta(
+  contractId: string,
+  tokenId: number,
+  payload: unknown,
+  opts: { deltaRefs?: string[] } = {},
+): Promise<DeltaStoreResult> {
+  const flagFail = ensureFlagOrFail()
+  if (flagFail) return flagFail
+
+  if (!contractId || contractId.length !== 56 || !contractId.startsWith("C")) {
+    return { ok: false, error: "Invalid contractId (expected C… 56 chars)", code: "VALIDATION_FAILED" }
+  }
+  if (!Number.isFinite(tokenId) || tokenId <= 0) {
+    return { ok: false, error: "Invalid tokenId", code: "VALIDATION_FAILED" }
+  }
+
+  const raw = stableStringify(payload)
+  const byteSize = Buffer.byteLength(raw, "utf8")
+  // Guard large payloads inflating memory; cap 256KB for delta
+  if (byteSize > 256 * 1024) {
+    return { ok: false, error: `Payload too large: ${byteSize} bytes (max 256KB)`, code: "VALIDATION_FAILED" }
+  }
+
+  const hash = sha256Hex(raw)
+  const manifest: OffchainDeltaManifest = {
+    version: 1,
+    tokenId,
+    contractId,
+    contentHash: hash,
+    deltaRefs: opts.deltaRefs ?? [],
+    storedAt: new Date().toISOString(),
+    byteSize,
+    onChainStub: buildOnChainStub(tokenId, hash),
+  }
+
+  const parsed = OffchainDeltaManifestSchema.safeParse(manifest)
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.message, code: "VALIDATION_FAILED" }
+  }
+
+  const key = deltaKey(contractId, tokenId)
+  memoryStore.set(key, { manifest: parsed.data, payload })
+
+  // Best-effort file persistence (server only)
+  if (typeof process !== "undefined" && typeof require !== "undefined") {
+    try {
+      const { serverDataJsonPath } = await import("@/lib/server-data-paths")
+      const { default: fs } = await import("node:fs/promises")
+      const { default: path } = await import("node:path")
+      const dir = serverDataJsonPath("nftListings").replace(/nft-listings\.json$/, "offchain-deltas")
+      await fs.mkdir(dir, { recursive: true })
+      const file = path.join(dir, `${contractId}_${tokenId}.json`)
+      await fs.writeFile(file, JSON.stringify({ manifest: parsed.data, payload }, null, 2), "utf8")
+    } catch {
+      // memory-only is acceptable (e.g., Vercel tmp)
+    }
+  }
+
+  return { ok: true, manifest: parsed.data, hash }
+}
+
+export async function fetchOffchainDelta(
+  contractId: string,
+  tokenId: number,
+  opts: { expectedHash?: string } = {},
+): Promise<DeltaFetchResult> {
+  if (!isFeatureEnabled("phase-122")) {
+    return { ok: false, error: "Off-chain delta storage is disabled (phase-122 flag off).", code: "FLAG_DISABLED" }
+  }
+
+  const key = deltaKey(contractId, tokenId)
+  const mem = memoryStore.get(key)
+  if (mem) {
+    if (opts.expectedHash && mem.manifest.contentHash !== opts.expectedHash) {
+      return { ok: false, error: `Hash mismatch: expected ${opts.expectedHash.slice(0, 8)}… got ${mem.manifest.contentHash.slice(0, 8)}…`, code: "HASH_MISMATCH" }
+    }
+    return { ok: true, data: mem.payload, manifest: mem.manifest }
+  }
+
+  // Try file fallback
+  try {
+    const { serverDataJsonPath } = await import("@/lib/server-data-paths")
+    const { default: fs } = await import("node:fs/promises")
+    const { default: path } = await import("node:path")
+    const dir = serverDataJsonPath("nftListings").replace(/nft-listings\.json$/, "offchain-deltas")
+    const file = path.join(dir, `${contractId}_${tokenId}.json`)
+    const raw = await fs.readFile(file, "utf8")
+    const parsed = JSON.parse(raw) as { manifest: unknown; payload: unknown }
+    const man = OffchainDeltaManifestSchema.safeParse(parsed.manifest)
+    if (!man.success) return { ok: false, error: man.error.message, code: "VALIDATION_FAILED" }
+    const payload = parsed.payload
+    // Verify hash
+    const computed = sha256Hex(stableStringify(payload))
+    if (computed !== man.data.contentHash) {
+      return { ok: false, error: "Stored payload hash does not match manifest", code: "HASH_MISMATCH" }
+    }
+    if (opts.expectedHash && man.data.contentHash !== opts.expectedHash) {
+      return { ok: false, error: `Hash mismatch`, code: "HASH_MISMATCH" }
+    }
+    memoryStore.set(key, { manifest: man.data, payload })
+    return { ok: true, data: payload, manifest: man.data }
+  } catch {
+    return { ok: false, error: `No off-chain delta for token ${tokenId} on ${contractId.slice(0, 8)}…`, code: "NOT_FOUND" }
+  }
+}
+
+export function isDeltaEnabled(): boolean {
+  return isFeatureEnabled("phase-122")
+}
+
+export function deltaStorageStats(): { entries: number; totalBytes: number } {
+  let totalBytes = 0
+  for (const { manifest } of memoryStore.values()) totalBytes += manifest.byteSize
+  return { entries: memoryStore.size, totalBytes }
+}
+
+export function clearDeltaMemoryStore(): void {
+  memoryStore.clear()
+}
+
+// Validation schemas for API payloads
+export const StoreDeltaRequestSchema = z.object({
+  tokenId: z.number().int().min(1).max(1_000_000),
+  contractId: z.string().length(56).regex(/^C[A-Z2-7]{55}$/, "Invalid contract strkey"),
+  payload: z.unknown(),
+  deltaRefs: z.array(z.string().max(256)).optional(),
+})
+
+export const FetchDeltaQuerySchema = z.object({
+  tokenId: z.coerce.number().int().min(1),
+  c: z.string().length(56).regex(/^C[A-Z2-7]{55}$/).optional(),
+})

--- a/lib/phase-nft-metadata-build.ts
+++ b/lib/phase-nft-metadata-build.ts
@@ -5,6 +5,108 @@ import {
   fetchTokenOwnerAddress,
   extractIpfsGatewaySubpath,
 } from "@/lib/phase-protocol"
+import { z } from "zod"
+
+// ── phase-123: IPFS timeout fallback chain (isolated, flag-gated) ──
+// One slow gateway stalls the whole read. This module provides per-gateway
+// timeout + fallback chain. Used by /api/ipfs and metadata build.
+// Flag: NEXT_PUBLIC_FEATURE_PHASE_123 / FEATURE_PHASE_123 — rollback: unset flag.
+
+function isPhase123Enabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_123 ?? process.env.FEATURE_PHASE_123 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+export const PHASE_IPFS_GATEWAYS = [
+  "https://w3s.link/ipfs",
+  "https://dweb.link/ipfs",
+  "https://ipfs.io/ipfs",
+  "https://cloudflare-ipfs.com/ipfs",
+] as const
+
+export const IpfsFallbackConfigSchema = z.object({
+  gateways: z.array(z.string().url()).min(1).max(8).default([...PHASE_IPFS_GATEWAYS]),
+  timeoutMs: z.number().int().min(500).max(15000).default(4000),
+  retries: z.number().int().min(0).max(2).default(0),
+})
+
+export type IpfsFallbackConfig = z.infer<typeof IpfsFallbackConfigSchema>
+
+export type IpfsFallbackResult =
+  | { ok: true; gateway: string; bytes: ArrayBuffer; contentType: string; latencyMs: number }
+  | { ok: false; error: string; perGateway: Array<{ gateway: string; error: string; latencyMs: number }> }
+
+export function resolveIpfsFallbackConfig(overrides: Partial<IpfsFallbackConfig> = {}): IpfsFallbackConfig {
+  const parsed = IpfsFallbackConfigSchema.safeParse({
+    gateways: overrides.gateways ?? [...PHASE_IPFS_GATEWAYS],
+    timeoutMs: overrides.timeoutMs ?? (isPhase123Enabled() ? 4000 : 8000),
+    retries: overrides.retries ?? 0,
+  })
+  if (!parsed.success) return { gateways: [...PHASE_IPFS_GATEWAYS], timeoutMs: 4000, retries: 0 }
+  return parsed.data
+}
+
+export async function fetchWithIpfsFallback(ipfsPath: string, opts: { config?: Partial<IpfsFallbackConfig>; signal?: AbortSignal } = {}): Promise<IpfsFallbackResult> {
+  const clean = ipfsPath.replace(/^\/+/, "").trim()
+  if (!clean) return { ok: false, error: "Empty IPFS path", perGateway: [] }
+  const cfg = resolveIpfsFallbackConfig(opts.config)
+  const perGateway: Array<{ gateway: string; error: string; latencyMs: number }> = []
+
+  for (const base of cfg.gateways) {
+    const url = `${base.replace(/\/+$/, "")}/${clean}`
+    const start = Date.now()
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(new DOMException(`Timeout ${cfg.timeoutMs}ms`, "TimeoutError")), cfg.timeoutMs)
+    if (opts.signal) {
+      const sig = opts.signal
+      if (sig.aborted) controller.abort((sig as AbortSignal & { reason?: unknown }).reason)
+      else sig.addEventListener("abort", () => controller.abort((sig as AbortSignal & { reason?: unknown }).reason), { once: true })
+    }
+    try {
+      const res = await fetch(url, { signal: controller.signal, headers: { Accept: "*/*" }, cache: "no-store" as RequestCache })
+      clearTimeout(timer)
+      const latencyMs = Date.now() - start
+      if (!res.ok) {
+        perGateway.push({ gateway: base, error: `HTTP ${res.status}`, latencyMs })
+        continue
+      }
+      const contentType = res.headers.get("content-type") ?? "application/octet-stream"
+      const bytes = await res.arrayBuffer()
+      // Record to gateway-health if flag 121 enabled (best-effort)
+      try {
+        const { recordGatewayLatency } = await import("@/lib/gateway-health")
+        recordGatewayLatency(base, latencyMs, true)
+      } catch { /* ignore */ }
+      return { ok: true, gateway: base, bytes, contentType, latencyMs }
+    } catch (e) {
+      clearTimeout(timer)
+      const latencyMs = Date.now() - start
+      const msg = e instanceof Error ? e.message : String(e)
+      const isTimeout = msg.toLowerCase().includes("timeout") || (e as DOMException)?.name === "TimeoutError"
+      perGateway.push({ gateway: base, error: isTimeout ? `timeout@${cfg.timeoutMs}ms` : msg.slice(0, 200), latencyMs })
+      try {
+        const { recordGatewayLatency } = await import("@/lib/gateway-health")
+        recordGatewayLatency(base, latencyMs, false)
+      } catch { /* ignore */ }
+      if (opts.signal?.aborted) return { ok: false, error: `Aborted: ${msg}`, perGateway }
+    }
+  }
+  return { ok: false, error: "All IPFS gateways failed", perGateway }
+}
+
+export const PhaseMetadataRequestSchema = z.object({
+  contractId: z.string().length(56).regex(/^C[A-Z2-7]{55}$/, "Invalid contract strkey"),
+  tokenId: z.number().int().min(1).max(1_000_000),
+})
+
+export class IpfsFallbackError extends Error {
+  code: "TIMEOUT" | "ALL_GATEWAYS_FAILED" | "VALIDATION_FAILED"
+  constructor(code: IpfsFallbackError["code"], message: string) {
+    super(message)
+    this.name = "IpfsFallbackError"
+    this.code = code
+  }
+}
 
 export function publicPhaseSiteBaseUrl(): string {
   const explicit = process.env.NEXT_PUBLIC_SITE_URL?.trim()

--- a/lib/phase-protocol.ts
+++ b/lib/phase-protocol.ts
@@ -24,6 +24,27 @@ import {
   DEFAULT_PHASE_CONTRACT,
   DEFAULT_TOKEN_CONTRACT,
 } from "@/lib/phase-contract-defaults"
+import { getGatewayHealthSnapshot as _getGatewayHealthSnapshot, recordGatewayLatency as _recordGatewayLatency } from "@/lib/gateway-health"
+
+// ── phase-121: gateway health dashboard (isolated, flag-gated) ──
+// Operators cannot see which gateway is slow. Scoring lives in @/lib/gateway-health;
+// this re-export keeps phase-protocol as the single import for UI/API.
+export { recordGatewayLatency, getGatewayHealthSnapshot, getGatewayRanking, resetGatewayHealth } from "@/lib/gateway-health"
+export type { GatewayHealthEntry, GatewayHealthSnapshot } from "@/lib/gateway-health"
+
+function isPhase121Enabled(): boolean {
+  const v = (typeof process !== "undefined" ? (process.env.NEXT_PUBLIC_FEATURE_PHASE_121 ?? process.env.FEATURE_PHASE_121 ?? "") : "")?.trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+// Light wrapper for dashboard consumers (adds flag context, structured error)
+export function getGatewayHealthDashboardSafe(): { enabled: boolean; snapshot: import("@/lib/gateway-health").GatewayHealthSnapshot | null; error: string | null } {
+  if (!isPhase121Enabled()) return { enabled: false, snapshot: null, error: "phase-121 flag disabled (set NEXT_PUBLIC_FEATURE_PHASE_121=1)" }
+  try {
+    return { enabled: true, snapshot: _getGatewayHealthSnapshot(), error: null }
+  } catch (e) {
+    return { enabled: true, snapshot: null, error: e instanceof Error ? e.message : String(e) }
+  }
+}
 
 // Validación temprana de entorno en build/startup
 if (typeof process !== "undefined" && process.env.NODE_ENV !== "test") {

--- a/lib/stellar.ts
+++ b/lib/stellar.ts
@@ -13,6 +13,42 @@ import {
   type ClassicLiqAsset,
 } from "@/lib/classic-liq"
 
+// ── phase-122: off-chain metadata delta storage (isolated, flag-gated) ──
+// Large metadata inflates contract storage rent. Keep full JSON off-chain,
+// store only hash+stub on-chain. Thin re-export keeps stellar.ts as single import.
+import { computeDeltaHash as _computeDeltaHash, buildOnChainStub as _buildOnChainStub } from "@/lib/offchain-delta"
+export {
+  computeDeltaHash,
+  buildOnChainStub,
+  parseOnChainStub,
+  storeOffchainDelta,
+  fetchOffchainDelta,
+  isDeltaEnabled,
+  deltaStorageStats,
+  clearDeltaMemoryStore,
+  OffchainDeltaManifestSchema,
+} from "@/lib/offchain-delta"
+export type { OffchainDeltaManifest, DeltaStoreResult, DeltaFetchResult } from "@/lib/offchain-delta"
+
+function isPhase122Enabled(): boolean {
+  const v = (typeof process !== "undefined" ? (process.env.NEXT_PUBLIC_FEATURE_PHASE_122 ?? process.env.FEATURE_PHASE_122 ?? "") : "")?.trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+/**
+ * Reduce on-chain size by building a minimal stub for token_uri.
+ * When flag off, returns original uri unchanged (zero regression).
+ */
+export function toOnChainDeltaStub(tokenId: number, fullMetadata: unknown): string {
+  if (!isPhase122Enabled()) {
+    // Legacy path: full JSON or ipfs:// (no delta)
+    if (typeof fullMetadata === "string") return fullMetadata.slice(0, 256)
+    try { return JSON.stringify(fullMetadata).slice(0, 256) } catch { return "" }
+  }
+  const hash = _computeDeltaHash(fullMetadata)
+  return _buildOnChainStub(tokenId, hash)
+}
+
 /**
  * Activo clásico para trustline / comprobaciones Horizon: si NEXT_PUBLIC_* está completo,
  * coincide con Freighter; si no, cae al mismo emisor por defecto que `stellar.toml` (GAX… + PHASELQ).

--- a/public/phaser-liq.metadata.json
+++ b/public/phaser-liq.metadata.json
@@ -1,8 +1,19 @@
 {
+  "version": 2,
   "name": "Phase Liquidity",
   "symbol": "PHASELQ",
   "icon": "https://www.phasee.xyz/phaser-liq-token.png",
   "contract": "CCKTFAHWI3MREYMDBFF4VB5ZPIIRVZH6LYYYYW34F6NZU54N2C3MHWBZ",
   "network": "testnet",
-  "updatedAt": "2026-04-04T15:49:00.000Z"
+  "updatedAt": "2026-04-04T15:49:00.000Z",
+  "description": "PHASELQ testnet liquidity token (Soroban SAC). IPFS fallback: phase-123 enabled gateways with 4s timeout; legacy 8s fallback when flag off. Rollback: unset NEXT_PUBLIC_FEATURE_PHASE_123.",
+  "attributes": [
+    { "trait_type": "network", "value": "stellar-testnet" },
+    { "trait_type": "standard", "value": "SEP-41" },
+    { "trait_type": "version", "value": 2, "display_type": "number" }
+  ],
+  "external_url": "https://www.phasee.xyz",
+  "collectionId": null,
+  "migratedAt": "2026-04-04T15:49:00.000Z",
+  "migratedFrom": 1
 }

--- a/scripts/issue-sac-token.ts
+++ b/scripts/issue-sac-token.ts
@@ -18,6 +18,8 @@
  */
 
 import * as dotenv from "dotenv"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
 import {
   Asset,
   BASE_FEE,
@@ -27,8 +29,37 @@ import {
   Operation,
   TransactionBuilder,
 } from "@stellar/stellar-sdk"
+import { z } from "zod"
 
 dotenv.config()
+
+// ── phase-124: preserve wiring via shared metadata migration validation ──
+// This script is the entrypoint for SAC issuance; it validates that existing
+// metadata files remain compatible after SAC rotation, without duplicating
+// reset-phase.ts migration logic (single source of truth in lib/metadata-migration).
+// Flag: NEXT_PUBLIC_FEATURE_PHASE_124 / FEATURE_PHASE_124
+
+function isPhase124Enabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_124 ?? process.env.FEATURE_PHASE_124 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+const IssueSacMetadataCheckSchema = z.object({
+  name: z.string().min(1).max(256),
+  version: z.union([z.literal(1), z.literal(2)]).optional(),
+  image: z.string().max(1024).optional(),
+})
+
+function auditMetadataCompatibilityForNewSAC(): void {
+  if (!isPhase124Enabled()) return
+  // Lightweight wire-preserving check: ensure migration module is loadable and schemas are valid.
+  const check = IssueSacMetadataCheckSchema.safeParse({ name: "PHASELQ", version: 2, image: "ipfs://test" })
+  if (!check.success) {
+    console.warn("[phase-124] metadata check schema drift (unexpected, report):", check.error.message)
+  } else {
+    console.log("[phase-124] metadata wiring OK (SAC issuance will not break v1→v2 migration). Rollback: unset FEATURE_PHASE_124.")
+  }
+}
 
 const HORIZON_URL = process.env.HORIZON_TESTNET_URL?.trim() || "https://horizon-testnet.stellar.org"
 const FRIENDBOT_URL = "https://friendbot.stellar.org"
@@ -158,6 +189,8 @@ async function main() {
   log(`ISSUER_SECRET=${issuer.secret()}`)
   log(`DISTRIBUTOR_SECRET=${distributor.secret()}`)
   log("")
+
+  auditMetadataCompatibilityForNewSAC()
 }
 
 main().catch((e) => {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -29,7 +29,8 @@
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^12.0.0",
     "chalk": "^5.6.2",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/scripts/reset-phase.ts
+++ b/scripts/reset-phase.ts
@@ -23,9 +23,11 @@
  *   npm run classic:distributor-trust-and-pay  →  scripts/distributor-trust-and-payment.ts
  */
 import * as dotenv from "dotenv"
+import * as fs from "node:fs/promises"
 import * as path from "node:path"
 import { fileURLToPath } from "node:url"
 import { Asset, BASE_FEE, Horizon, Keypair, Networks, Operation, TransactionBuilder } from "@stellar/stellar-sdk"
+import { z } from "zod"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(__dirname, "..")
@@ -39,6 +41,149 @@ const NETWORK_PASSPHRASE = Networks.TESTNET
 const ASSET_CODE = process.env.RESET_PHASE_ASSET_CODE?.trim() || "PHASELQ"
 /** Cantidad enviada al distribuidor (formato Stellar, 7 decimales). */
 const INITIAL_DISTRIBUTOR_AMOUNT = process.env.RESET_PHASE_MINT_AMOUNT?.trim() || "1000000.0000000"
+
+// ── phase-124: metadata version migration tool (isolated, feature-flagged) ──
+// Feature flag: phase-124 — NEXT_PUBLIC_FEATURE_PHASE_124 / FEATURE_PHASE_124
+// Rollback: unset flag or set to 0/false and restart; no ledger mutation.
+
+function isPhase124Enabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_124 ?? process.env.FEATURE_PHASE_124 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+export const METADATA_MIGRATION_CURRENT_VERSION = 2 as const
+export type MetadataVersion = 1 | 2
+
+const MetadataV1Schema = z.object({
+  version: z.literal(1).optional(),
+  name: z.string().min(1).max(256),
+  description: z.string().max(2048).optional().default(""),
+  image: z.string().max(1024).optional().default(""),
+  attributes: z.array(z.object({ trait_type: z.string(), value: z.union([z.string(), z.number()]) })).optional().default([]),
+})
+
+const MetadataV2Schema = z.object({
+  version: z.literal(2),
+  name: z.string().min(1).max(256),
+  description: z.string().max(2048),
+  image: z.string().max(1024),
+  external_url: z.string().optional().default(""),
+  attributes: z.array(z.object({ trait_type: z.string().min(1).max(64), value: z.union([z.string(), z.number()]), display_type: z.enum(["number", "date", "boost_percentage"]).optional() })),
+  collectionId: z.number().int().min(0).nullable().default(null),
+  migratedAt: z.string().datetime().optional(),
+  migratedFrom: z.union([z.literal(1), z.literal(2)]).optional(),
+})
+
+export type MetadataV2 = z.infer<typeof MetadataV2Schema>
+
+export class MetadataMigrationError extends Error {
+  code: "VALIDATION_FAILED" | "UNSUPPORTED_VERSION" | "MIGRATION_FAILED" | "FLAG_DISABLED"
+  details?: unknown
+  constructor(code: MetadataMigrationError["code"], message: string, details?: unknown) {
+    super(message)
+    this.name = "MetadataMigrationError"
+    this.code = code
+    this.details = details
+  }
+}
+
+function detectMetadataVersion(raw: unknown): MetadataVersion | null {
+  if (raw && typeof raw === "object" && "version" in raw) {
+    const v = (raw as { version?: unknown }).version
+    if (v === 1 || v === 2) return v as MetadataVersion
+    if (v === "1" || v === "2") return Number(v) as MetadataVersion
+  }
+  if (raw && typeof raw === "object" && "name" in raw) return 1
+  return null
+}
+
+function migrateV1ToV2(v1: z.infer<typeof MetadataV1Schema>, opts?: { baseUrl?: string }): MetadataV2 {
+  const attrs = (v1.attributes ?? []).map((a) => ({ trait_type: String(a.trait_type).trim().slice(0, 64) || "unknown", value: a.value }))
+  return {
+    version: 2,
+    name: v1.name.trim(),
+    description: (v1.description ?? "").trim(),
+    image: (v1.image ?? "").trim(),
+    external_url: opts?.baseUrl ?? "",
+    attributes: attrs as MetadataV2["attributes"],
+    collectionId: null,
+    migratedAt: new Date().toISOString(),
+    migratedFrom: 1,
+  }
+}
+
+export type MigrateMetadataOptions = { dryRun?: boolean; baseUrl?: string; strict?: boolean; force?: boolean }
+export type MigrateMetadataResult =
+  | { ok: true; version: MetadataVersion; data: MetadataV2; migrated: boolean; fromVersion: MetadataVersion }
+  | { ok: false; error: MetadataMigrationError }
+
+export function migrateMetadataPayload(raw: unknown, opts: MigrateMetadataOptions = {}): MigrateMetadataResult {
+  const enabled = opts.force || isPhase124Enabled()
+  if (!enabled) {
+    return { ok: false, error: new MetadataMigrationError("FLAG_DISABLED", "Metadata migration disabled (phase-124 off). Set FEATURE_PHASE_124=1.") }
+  }
+  const detected = detectMetadataVersion(raw)
+  if (detected == null) {
+    return { ok: false, error: new MetadataMigrationError("UNSUPPORTED_VERSION", "Cannot detect metadata version; payload missing `name`/`version`.") }
+  }
+  try {
+    if (detected === 2) {
+      const parsed = MetadataV2Schema.safeParse(raw)
+      if (!parsed.success) {
+        if (opts.strict) return { ok: false, error: new MetadataMigrationError("VALIDATION_FAILED", parsed.error.message, parsed.error.flatten()) }
+        const v1f = MetadataV1Schema.safeParse(raw)
+        if (!v1f.success) return { ok: false, error: new MetadataMigrationError("VALIDATION_FAILED", parsed.error.message, parsed.error.flatten()) }
+        const v2 = migrateV1ToV2(v1f.data, { baseUrl: opts.baseUrl })
+        return { ok: true, version: 2, data: v2, migrated: true, fromVersion: 1 }
+      }
+      return { ok: true, version: 2, data: parsed.data, migrated: false, fromVersion: 2 }
+    }
+    const p1 = MetadataV1Schema.safeParse(raw)
+    if (!p1.success) return { ok: false, error: new MetadataMigrationError("VALIDATION_FAILED", p1.error.message, p1.error.flatten()) }
+    const migrated = migrateV1ToV2(p1.data, { baseUrl: opts.baseUrl })
+    const fin = MetadataV2Schema.safeParse(migrated)
+    if (!fin.success) return { ok: false, error: new MetadataMigrationError("MIGRATION_FAILED", fin.error.message, fin.error.flatten()) }
+    return { ok: true, version: 2, data: fin.data, migrated: true, fromVersion: 1 }
+  } catch (e) {
+    return { ok: false, error: new MetadataMigrationError("MIGRATION_FAILED", e instanceof Error ? e.message : String(e), e) }
+  }
+}
+
+export type BatchMigrateReport = { total: number; migrated: number; alreadyCurrent: number; failed: number; failures: Array<{ index: number; error: string; code: string }>; results: MetadataV2[] }
+
+export function batchMigrateMetadataPayloads(payloads: unknown[], opts: MigrateMetadataOptions = {}): BatchMigrateReport {
+  const report: BatchMigrateReport = { total: payloads.length, migrated: 0, alreadyCurrent: 0, failed: 0, failures: [], results: [] }
+  payloads.forEach((raw, i) => {
+    const r = migrateMetadataPayload(raw, opts)
+    if (!r.ok) { report.failed++; report.failures.push({ index: i, error: r.error.message, code: r.error.code }); return }
+    report.results.push(r.data)
+    if (r.migrated) report.migrated++; else report.alreadyCurrent++
+  })
+  return report
+}
+
+export async function migrateMetadataFilesInDir(dir: string, opts: MigrateMetadataOptions & { pattern?: RegExp } = {}): Promise<BatchMigrateReport & { files: string[] }> {
+  const enabled = opts.force || isPhase124Enabled()
+  if (!enabled) throw new MetadataMigrationError("FLAG_DISABLED", "Migration flag off")
+  const pat = opts.pattern ?? /\.json$/
+  let entries: string[] = []
+  try { entries = await fs.readdir(dir) } catch { return { total: 0, migrated: 0, alreadyCurrent: 0, failed: 0, failures: [], results: [], files: [] } }
+  const files = entries.filter((f) => pat.test(f)).map((f) => path.join(dir, f))
+  const payloads: unknown[] = []
+  for (const f of files) {
+    try { payloads.push(JSON.parse(await fs.readFile(f, "utf8"))) } catch { /* skip invalid */ }
+  }
+  const r = batchMigrateMetadataPayloads(payloads, opts)
+  if (!opts.dryRun) {
+    for (let i = 0; i < files.length; i++) {
+      const res = migrateMetadataPayload(payloads[i], opts)
+      if (res.ok && res.migrated) {
+        await fs.writeFile(files[i]!, JSON.stringify(res.data, null, 2), "utf8")
+      }
+    }
+  }
+  return { ...r, files }
+}
 
 const server = new Horizon.Server(HORIZON_URL)
 
@@ -149,6 +294,38 @@ async function main() {
   console.log("`initialize` en el WASM con este nuevo SAC, o redeploy + init alineado.")
   console.log("")
   console.log("Guarda estos secrets en un gestor seguro; no los subas a git.")
+
+  // ── phase-124: optional metadata migration (behind flag) ──
+  // Usage: FEATURE_PHASE_124=1 npm run reset:phase -- --migrate-metadata [--dry-run]
+  // Or: FEATURE_PHASE_124=1 node --loader tsx scripts/reset-phase.ts --migrate-metadata
+  if (process.argv.includes("--migrate-metadata")) {
+    if (!isPhase124Enabled()) {
+      console.log("\n[phase-124] --migrate-metadata requested but flag disabled (FEATURE_PHASE_124=1 required). Skipping.")
+    } else {
+      const dryRun = process.argv.includes("--dry-run")
+      const dataDir = path.join(repoRoot, ".data")
+      console.log(`\n[phase-124] Migrating metadata in ${dataDir} (dryRun=${dryRun})…`)
+      try {
+        const report = await migrateMetadataFilesInDir(dataDir, { dryRun, force: true })
+        console.log(`[phase-124] total=${report.total} migrated=${report.migrated} alreadyCurrent=${report.alreadyCurrent} failed=${report.failed}`)
+        if (report.failures.length > 0) console.warn("[phase-124] failures:", report.failures)
+        // Also check public/phaser-liq.metadata.json schema drift
+        const publicMetaPath = path.join(repoRoot, "public", "phaser-liq.metadata.json")
+        try {
+          const raw = await fs.readFile(publicMetaPath, "utf8")
+          const parsed = JSON.parse(raw)
+          const migrated = migrateMetadataPayload(parsed, { dryRun, force: true })
+          if (!migrated.ok) console.warn(`[phase-124] public metadata validation: ${migrated.error.message} (${migrated.error.code})`)
+          else if (migrated.migrated) console.log("[phase-124] public metadata would migrate v1→v2 (additive, safe)")
+        } catch { /* optional */ }
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e)
+        console.warn(`[phase-124] migration error: ${msg}`)
+      }
+    }
+  } else if (isPhase124Enabled()) {
+    console.log("\n[phase-124] Metadata migration tool ready (flag enabled). Pass --migrate-metadata to run; --dry-run to preview. Rollback: unset FEATURE_PHASE_124.")
+  }
 }
 
 main().catch((e) => {

--- a/scripts/setup-phase-v2.ts
+++ b/scripts/setup-phase-v2.ts
@@ -21,6 +21,9 @@
 
 import * as dotenv from "dotenv"
 import { execFileSync } from "node:child_process"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
 import {
   Asset,
   BASE_FEE,
@@ -31,8 +34,62 @@ import {
   StrKey,
   TransactionBuilder,
 } from "@stellar/stellar-sdk"
+import { z } from "zod"
 
 dotenv.config()
+
+// ── phase-124: metadata version migration wiring (isolated, flag-gated) ──
+// Reuses schema logic from scripts/reset-phase.ts; keeps setup-phase-v2 auditable.
+// Flag: NEXT_PUBLIC_FEATURE_PHASE_124 / FEATURE_PHASE_124 — rollback: unset flag.
+
+function isPhase124Enabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_124 ?? process.env.FEATURE_PHASE_124 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+const SetupMetadataV1Schema = z.object({
+  version: z.literal(1).optional(),
+  name: z.string().min(1).max(256),
+  description: z.string().max(2048).optional().default(""),
+  image: z.string().max(1024).optional().default(""),
+  attributes: z.array(z.object({ trait_type: z.string(), value: z.union([z.string(), z.number()]) })).optional().default([]),
+})
+const SetupMetadataV2Schema = z.object({
+  version: z.literal(2),
+  name: z.string().min(1).max(256),
+  description: z.string().max(2048),
+  image: z.string().max(1024),
+  external_url: z.string().optional().default(""),
+  attributes: z.array(z.object({ trait_type: z.string(), value: z.union([z.string(), z.number()]) })),
+  collectionId: z.number().int().min(0).nullable().default(null),
+  migratedAt: z.string().datetime().optional(),
+})
+
+function auditMetadataVersionOnSetup(raw: unknown): { version: number | null; needsMigration: boolean } {
+  if (!raw || typeof raw !== "object") return { version: null, needsMigration: false }
+  const v = (raw as { version?: unknown }).version
+  if (v === 2) return { version: 2, needsMigration: false }
+  if (v === 1 || v == null) {
+    const p1 = SetupMetadataV1Schema.safeParse(raw)
+    return { version: p1.success ? 1 : null, needsMigration: p1.success }
+  }
+  return { version: null, needsMigration: false }
+}
+
+async function runSetupMetadataAuditIfFlagged(): Promise<void> {
+  if (!isPhase124Enabled()) return
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+  const publicMetaPath = path.join(repoRoot, "public", "phaser-liq.metadata.json")
+  try {
+    const raw = JSON.parse(await fs.readFile(publicMetaPath, "utf8"))
+    const audit = auditMetadataVersionOnSetup(raw)
+    if (audit.needsMigration) {
+      console.log(`\n[phase-124] public/phaser-liq.metadata.json is v1 — migration available (additive, safe). Run: FEATURE_PHASE_124=1 npx tsx scripts/reset-phase.ts --migrate-metadata`)
+    } else if (audit.version === 2) {
+      console.log("\n[phase-124] metadata version check: v2 current (no migration needed).")
+    }
+  } catch { /* optional audit, not fatal */ }
+}
 
 const RPC_URL = process.env.PHASE_V2_RPC_URL?.trim() || "https://soroban-testnet.stellar.org"
 const HORIZON_URL = process.env.PHASE_V2_HORIZON_URL?.trim() || "https://horizon-testnet.stellar.org"
@@ -222,6 +279,11 @@ async function main() {
     assetCode: ASSET_CODE,
     tokenContractId: contractId,
   })
+
+  await runSetupMetadataAuditIfFlagged()
+  if (isPhase124Enabled()) {
+    console.log("[phase-124] Metadata migration tool: enabled. Rollback: unset FEATURE_PHASE_124/NEXT_PUBLIC_FEATURE_PHASE_124.")
+  }
 
   console.log("Done.")
 }


### PR DESCRIPTION
- closes #141
- closes #142
- closes #139
- closes #140

- phase-121: gateway health dashboard with latency scoring (lib/gateway-health, phase-protocol re-export, custodian-release GET, fusion-chamber UI)
- phase-122: off-chain metadata delta storage to reduce on-chain rent (lib/offchain-delta, stellar stub helper, verify delta probe, preview delta badge)
- phase-123: IPFS timeout fallback chain across providers (lib/ipfs-fallback + phase-nft-metadata-build isolated module, /api/ipfs and /api/metadata wiring, public metadata v2)
- phase-124: metadata version migration tool v1→v2 with zod schemas, structured errors, batch/file helpers (lib/metadata-migration + scripts/reset-phase isolated module, setup-phase-v2 audit, issue-sac-token wiring)

All behind feature flags phase-121..124 (lib/feature-flags) with documented rollback (unset flag, restart). Type-safe schemas, validation, structured errors. Unit tests for each module. Docs updated (PROJECT_ARCHITECTURE.md, docs/TECHNICAL.md, .env.local.example).