### PR TITLE
feat: phase-107/111/113/114 — continuity check, locale cache, takedown, timeline

### DIFF
--- a/PROJECT_ARCHITECTURE.md
+++ b/PROJECT_ARCHITECTURE.md
@@ -126,6 +126,10 @@ Owns:
 
 | Flag | Env | Purpose | Default | Rollback |
 |------|-----|---------|---------|----------|
+| `phase-107` | `NEXT_PUBLIC_FEATURE_PHASE_107` / `FEATURE_PHASE_107` | AI story-arc continuity check against a world's recent narratives (Gemini) | off | Unset var, restart — generation skips the check, narratives save unconditionally as before |
+| `phase-111` | `NEXT_PUBLIC_FEATURE_PHASE_111` / `FEATURE_PHASE_111` | Localized narrative caching per (tokenId, lang) with short TTL | off | Unset var, restart — reads bypass the cache and hit the JSON store directly |
+| `phase-113` | `NEXT_PUBLIC_FEATURE_PHASE_113` / `FEATURE_PHASE_113` | Narrative content moderation with takedown/restore flow for signals | off | Unset var, restart — moderate endpoint returns 404, taken-down signals remain visible (data untouched) |
+| `phase-114` | `NEXT_PUBLIC_FEATURE_PHASE_114` / `FEATURE_PHASE_114` | Achievement timeline visualization (chronological world-event view) | off | Unset var, restart — `timeline` field omitted from `/api/achievements`, badge grid unchanged |
 | `phase-116` | `NEXT_PUBLIC_FEATURE_PHASE_116` / `FEATURE_PHASE_116` | Narrative contributor attribution & credit ledger (co-author on-chain credit) | off | Unset var, restart — ledger reads return empty, writes no-op; JSON sidecar remains on disk (no ledger revert) |
 | `phase-117` | `NEXT_PUBLIC_FEATURE_PHASE_117` / `FEATURE_PHASE_117` | Multi-gateway IPFS pinning with redundancy (quorum, gateway fallback) | off | Unset var, restart — pin reverts to single Pinata gateway, avatar reads use legacy single URL |
 | `phase-119` | `NEXT_PUBLIC_FEATURE_PHASE_119` / `FEATURE_PHASE_119` | CID content-addressing cache with integrity checks (tamper-evident) | off | Unset var, restart — cache disabled, verification skipped; cached files remain inert |

--- a/app/api/achievements/route.ts
+++ b/app/api/achievements/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server"
 import { StrKey } from "@stellar/stellar-sdk"
-import { getAchievements, getWalletData } from "@/lib/achievement-store"
+import { getAchievements, getWalletData, getAchievementTimeline, isTimelineVisualizationEnabled } from "@/lib/achievement-store"
 import { createApiRequestContext } from "@/lib/api-observability"
 
 export const runtime = "nodejs"
@@ -23,9 +23,12 @@ export async function GET(request: NextRequest) {
       getWalletData(wallet),
     ])
 
+    const timeline = isTimelineVisualizationEnabled() ? await getAchievementTimeline(wallet) : undefined
+
     return api.json(
       {
         achievements,
+        ...(timeline !== undefined ? { timeline } : {}),
         counters: {
           mint_count: data.mint_count ?? 0,
           daily_streak: data.daily_streak ?? 0,

--- a/app/api/narrator/route.ts
+++ b/app/api/narrator/route.ts
@@ -7,6 +7,7 @@ import {
   getNarrativeForToken,
 } from "@/lib/narrative-world-store"
 import { createNotification } from "@/lib/notification-store"
+import { checkNarrativeContinuity } from "@/lib/story-arc-continuity"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -124,6 +125,18 @@ export async function POST(request: NextRequest) {
     const msg = e instanceof Error ? e.message : String(e)
     console.error("[narrator] Gemini failed", { tokenId, collectionId, msg })
     return NextResponse.json({ error: `Gemini error: ${msg}` }, { status: 500 })
+  }
+
+  const continuity = await checkNarrativeContinuity(
+    world.world_name,
+    narrative,
+    recentNarratives.map((n) => n.narrative),
+  )
+  if (continuity && !continuity.consistent) {
+    return NextResponse.json(
+      { error: `Continuity check failed: ${continuity.reason}`, code: "CONTINUITY_CONTRADICTION" },
+      { status: 409 },
+    )
   }
 
   await saveNarrativeForToken(tokenId, {

--- a/app/api/signals/[id]/moderate/route.ts
+++ b/app/api/signals/[id]/moderate/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getSignal, takedownSignal, restoreSignal, isModerationEnabled } from "@/lib/signal-store"
+import { createNotification } from "@/lib/notification-store"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+type ModerateBody = {
+  action?: unknown
+  reason?: unknown
+}
+
+/**
+ * POST /api/signals/[id]/moderate
+ *
+ * Takes down or restores a signal (narrative content moderation, phase-113).
+ * Body JSON: { "action": "takedown" | "restore", "reason"?: string }
+ * Requires header `x-admin-key` equal to `PHASE_ADMIN_KEY` if defined.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!isModerationEnabled()) {
+    return NextResponse.json({ error: "Moderation is disabled (set NEXT_PUBLIC_FEATURE_PHASE_113=1)" }, { status: 404 })
+  }
+
+  const adminKey = process.env.PHASE_ADMIN_KEY?.trim()
+  if (adminKey) {
+    const provided = request.headers.get("x-admin-key")?.trim()
+    if (provided !== adminKey) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 })
+    }
+  }
+
+  const { id } = await params
+  let body: ModerateBody
+  try {
+    body = (await request.json()) as ModerateBody
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  const action = body.action
+  if (action !== "takedown" && action !== "restore") {
+    return NextResponse.json({ error: "action must be 'takedown' or 'restore'" }, { status: 400 })
+  }
+
+  const existing = await getSignal(id)
+  if (!existing) {
+    return NextResponse.json({ error: "Signal not found" }, { status: 404 })
+  }
+
+  try {
+    if (action === "takedown") {
+      const reason = typeof body.reason === "string" && body.reason.trim() ? body.reason.trim() : "Violates community guidelines"
+      const signal = await takedownSignal(id, reason)
+      void createNotification(signal.author_wallet, "content_takedown", {
+        signal_id: id,
+        signal_title: signal.title,
+        reason,
+      }).catch(() => { /* silent */ })
+      return NextResponse.json({ signal })
+    }
+
+    const signal = await restoreSignal(id)
+    return NextResponse.json({ signal })
+  } catch {
+    return NextResponse.json({ error: "Signal not found" }, { status: 404 })
+  }
+}

--- a/app/api/world/narrative/[token_id]/route.ts
+++ b/app/api/world/narrative/[token_id]/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getNarrativeForToken } from "@/lib/narrative-world-store"
+import { getNarrativeForTokenCached } from "@/lib/narrative-world-store"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   context: { params: Promise<{ token_id: string }> },
 ) {
   const { token_id } = await context.params
@@ -14,6 +14,7 @@ export async function GET(
     return NextResponse.json({ error: "token_id inválido" }, { status: 400 })
   }
 
-  const narrative = await getNarrativeForToken(tokenId)
+  const lang = request.nextUrl.searchParams.get("lang")?.trim() || "en"
+  const narrative = await getNarrativeForTokenCached(tokenId, lang)
   return NextResponse.json({ narrative })
 }

--- a/components/notifications-modal.tsx
+++ b/components/notifications-modal.tsx
@@ -18,6 +18,7 @@ type NotificationType =
   | "offer_accepted"
   | "offer_rejected"
   | "achievement_unlocked"
+  | "content_takedown"
 
 type Notification = {
   id: string
@@ -126,6 +127,13 @@ function notifText(n: Notification, lang: string): { text: string; url: string }
           : `Achievement unlocked: ${String(d.achievement_name ?? "")}`,
         url: `/profile`,
       }
+    case "content_takedown":
+      return {
+        text: es
+          ? `Tu señal "${String(d.signal_title ?? "")}" fue retirada: ${String(d.reason ?? "")}`
+          : `Your signal "${String(d.signal_title ?? "")}" was taken down: ${String(d.reason ?? "")}`,
+        url: `/signals`,
+      }
     default:
       return { text: es ? "Nueva actividad" : "New activity", url: "/" }
   }
@@ -143,6 +151,7 @@ const NOTIF_ICONS: Record<NotificationType, string> = {
   offer_accepted: "✓",
   offer_rejected: "✕",
   achievement_unlocked: "★",
+  content_takedown: "⚠",
 }
 
 function timeAgo(ts: number): string {

--- a/components/profile-panel.tsx
+++ b/components/profile-panel.tsx
@@ -608,6 +608,7 @@ type AchievementsTabCopy = {
   achievementsLocked: string
   achievementsEmpty: string
   achievementsProgress: string
+  achievementsTimeline: string
 }
 
 const ALL_ACHIEVEMENT_IDS = [
@@ -631,17 +632,28 @@ const ACHIEVEMENT_META: Record<string, { name: string; icon: string; desc_en: st
   phaselq_100:      { name: "PHASELQ ×100",      icon: "◈", desc_en: "Earned 100+ PHASELQ",          desc_es: "100+ PHASELQ ganados" },
 }
 
+type TimelineEntry = {
+  id: string
+  name: string
+  unlocked_at: number
+}
+
 function AchievementsTab({ address, t, lang }: { address: string; t: AchievementsTabCopy; lang: string }) {
   const [unlocked, setUnlocked] = useState<AchievementEntry[]>([])
+  const [timeline, setTimeline] = useState<TimelineEntry[] | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     let cancelled = false
     setLoading(true)
     fetch(`/api/achievements?wallet=${encodeURIComponent(address)}`)
-      .then((r) => r.json() as Promise<{ achievements?: AchievementEntry[] }>)
-      .then((data) => { if (!cancelled) setUnlocked(data.achievements ?? []) })
-      .catch(() => { if (!cancelled) setUnlocked([]) })
+      .then((r) => r.json() as Promise<{ achievements?: AchievementEntry[]; timeline?: TimelineEntry[] }>)
+      .then((data) => {
+        if (cancelled) return
+        setUnlocked(data.achievements ?? [])
+        setTimeline(data.timeline ?? null)
+      })
+      .catch(() => { if (!cancelled) { setUnlocked([]); setTimeline(null) } })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
   }, [address])
@@ -687,6 +699,35 @@ function AchievementsTab({ address, t, lang }: { address: string; t: Achievement
 
   return (
     <div className="flex flex-col gap-3 pt-1">
+      {/* Timeline (phase-114) */}
+      {timeline && timeline.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <p className="font-mono text-[8px] uppercase tracking-widest text-zinc-600">
+            {t.achievementsTimeline}
+          </p>
+          <div className="flex flex-col gap-0 border-l pl-2.5" style={{ borderColor: "rgba(124,58,237,0.3)" }}>
+            {timeline.map((event) => {
+              const meta = ACHIEVEMENT_META[event.id]
+              const date = new Date(event.unlocked_at)
+              return (
+                <div key={`${event.id}-${event.unlocked_at}`} className="relative py-1.5">
+                  <span
+                    className="absolute -left-[13px] top-2 h-1.5 w-1.5 rounded-full"
+                    style={{ background: "#7c3aed" }}
+                  />
+                  <p className="font-mono text-[9px] font-medium" style={{ color: "#c4b5fd" }}>
+                    {meta?.icon ?? "◈"} {event.name}
+                  </p>
+                  <p className="font-mono text-[8px]" style={{ color: "#71717a" }}>
+                    {date.toLocaleDateString(lang === "es" ? "es-ES" : "en-US")}
+                  </p>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
       {/* Unlocked */}
       {unlockedList.length > 0 && (
         <div className="flex flex-col gap-1.5">
@@ -802,6 +843,7 @@ export function ProfilePanel({ open, onOpenChange, address, disconnect }: Profil
           achievementsLocked: "// BLOQUEADOS",
           achievementsEmpty: "[ SIN_LOGROS ]",
           achievementsProgress: "Progreso",
+          achievementsTimeline: "// CRONOLOGÍA",
           placeholder: {
             displayName: "alias o nombre",
             twitter: "@handle",
@@ -870,6 +912,7 @@ export function ProfilePanel({ open, onOpenChange, address, disconnect }: Profil
           achievementsLocked: "// LOCKED",
           achievementsEmpty: "[ NO_ACHIEVEMENTS ]",
           achievementsProgress: "Progress",
+          achievementsTimeline: "// TIMELINE",
           placeholder: {
             displayName: "alias or name",
             twitter: "@handle",

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -71,13 +71,16 @@ flowchart TB
 | `lib/classic-liq.ts` | Classic asset trustline utilities (`changeTrust` XDR, Horizon checks) + CID integrity helpers via `cid-cache` (phase-119) |
 | `lib/phase-copy.ts` | Centralized i18n dictionary (EN/ES) |
 | `lib/server-data-paths.ts` | Writable data location abstraction |
-| `lib/feature-flags.ts` | Flag registry (phase-116,117,119,120 + 121..124, env resolution, rollback notes) |
+| `lib/feature-flags.ts` | Flag registry (phase-107,111,113,114 + 116,117,119,120 + 121..124, env resolution, rollback notes) |
+| `lib/story-arc-continuity.ts` | AI story-arc continuity check against recent world narratives (phase-107) |
+| `lib/narrative-world-store.ts` | World/narrative JSON store + localized per-(tokenId,lang) narrative cache (phase-111) |
 | `lib/ipfs-upload-retry.ts` | IPFS upload retry w/ exponential backoff + sha256 checksum (phase-120) |
 | `lib/cid-cache.ts` | CID content-addressing cache with integrity verification (phase-119) |
 | `lib/ipfs-pinning.ts` | Multi-gateway pinning with quorum + fallback fetch (phase-117) |
 | `lib/profile-store.ts` | Profile JSON store + avatar redundancy helpers (phase-117) |
 | `lib/contributor-ledger.ts` | Contributor ledger & credit distribution (phase-116) |
-| `lib/signal-store.ts` | Signals/replies + attribution ledger wiring (phase-116) |
+| `lib/signal-store.ts` | Signals/replies + attribution ledger wiring (phase-116) + moderation takedown/restore (phase-113) |
+| `lib/achievement-store.ts` | Achievement unlocks JSON store + chronological timeline (phase-114) |
 | `lib/gateway-health.ts` | Gateway latency scoring + dashboard snapshot (phase-121) |
 | `lib/offchain-delta.ts` | Off-chain delta store, hash/stub helpers (phase-122) |
 | `lib/ipfs-fallback.ts` / `lib/phase-nft-metadata-build.ts` | IPFS timeout fallback chain (phase-123) |
@@ -127,6 +130,10 @@ All handlers live in `app/api/**/route.ts`.
 
 | Flag | Route | Extension | Flag off |
 |------|-------|-----------|----------|
+| `phase-107` | `POST /api/narrator` | Checks new narrative against the world's recent narratives (Gemini); `409 CONTINUITY_CONTRADICTION` on a detected contradiction | No check, generation always saves |
+| `phase-111` | `GET /api/world/narrative/[token_id]` | Reads through a per-(tokenId, `?lang=`) cache with a short TTL | Direct store read every request |
+| `phase-113` | `POST /api/signals/[id]/moderate` | Takedown/restore a signal (`x-admin-key` gated); taken-down signals excluded from `GET /api/signals` | `404` disabled, no filtering |
+| `phase-114` | `GET /api/achievements` | Adds `timeline` field: achievement unlocks ordered oldest-first with names | Field omitted |
 | `phase-116` | `POST/GET /api/signals/[id]/replies` | Narrative contributor attribution: `contributors`, `creditLedger` on reply create; `GET` ledger endpoint with shareBps/roles | `404` disabled, ledger empty |
 | `phase-117` | `GET/POST /api/profile/avatar` | Multi-gateway redundancy: `GET` rewrites avatar URL via verified gateway (headers `X-Phase117`), `POST` pins with quorum (`quorum`, `achieved`, `checksum`) | Single gateway, no quorum |
 | `phase-119` | `POST/GET /api/classic-liq/trustline` | CID cache + integrity: validates `cid`/`expectedSha256`/`cidPath`, `GET` exposes cache stats, headers `X-Phase119` | Direct submit, no verification |
@@ -193,12 +200,16 @@ Critical groups:
 - Gemini runtime (`GEMINI_API_KEY`)
 - Writable server data directory (`PHASE_SERVER_DATA_DIR`)
 
-### 9.1 Feature flags (phase-116..124)
+### 9.1 Feature flags (phase-107,111,113,114 + 116..124)
 
 All flags default to **off** (safe rollback). Set to `1`/`true` to enable.
 
 ```
-# Enable all eight (example)
+# Enable all twelve (example)
+NEXT_PUBLIC_FEATURE_PHASE_107=1
+NEXT_PUBLIC_FEATURE_PHASE_111=1
+NEXT_PUBLIC_FEATURE_PHASE_113=1
+NEXT_PUBLIC_FEATURE_PHASE_114=1
 NEXT_PUBLIC_FEATURE_PHASE_116=1
 NEXT_PUBLIC_FEATURE_PHASE_117=1
 NEXT_PUBLIC_FEATURE_PHASE_119=1

--- a/lib/achievement-store.ts
+++ b/lib/achievement-store.ts
@@ -179,3 +179,30 @@ export async function checkAndUnlock(
   await writeStore(store)
   return newUnlocks
 }
+
+// ─── phase-114: timeline visualization for world events ────────────────────
+// Isolated, flag-gated. Achievement unlocks are the wallet's chronology of
+// world events; previously only exposed as an unordered badge grid. When
+// enabled, exposes unlocks ordered by unlocked_at for a timeline view.
+// When flag off, callers keep using getAchievements() (zero regression).
+// Rollback: unset NEXT_PUBLIC_FEATURE_PHASE_114 / FEATURE_PHASE_114.
+
+export function isTimelineVisualizationEnabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_114 ?? process.env.FEATURE_PHASE_114 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+export type TimelineEvent = {
+  id: AchievementId
+  name: string
+  unlocked_at: number
+}
+
+/** Returns the wallet's achievement unlocks ordered oldest-first, with display names attached. */
+export async function getAchievementTimeline(wallet: string): Promise<TimelineEvent[]> {
+  const achievements = await getAchievements(wallet)
+  return achievements
+    .slice()
+    .sort((a, b) => a.unlocked_at - b.unlocked_at)
+    .map((a) => ({ id: a.id, name: ACHIEVEMENT_NAMES[a.id] ?? a.id, unlocked_at: a.unlocked_at }))
+}

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -5,6 +5,10 @@
  * Rollback: unset the env var or set to "0"/"false" and restart. No migration to undo.
  *
  * Flags:
+ * - phase-107: AI story-arc continuity validator across artifacts
+ * - phase-111: localized narrative caching per language pack
+ * - phase-113: narrative content moderation with takedown flow
+ * - phase-114: timeline visualization for world events (achievements)
  * - phase-121: gateway health dashboard with latency scoring
  * - phase-122: off-chain metadata delta storage
  * - phase-123: IPFS timeout fallback chain
@@ -12,6 +16,10 @@
  */
 
 export type PhaseFeatureFlag =
+  | "phase-107"
+  | "phase-111"
+  | "phase-113"
+  | "phase-114"
   | "phase-116"
   | "phase-117"
   | "phase-119"
@@ -22,6 +30,10 @@ export type PhaseFeatureFlag =
   | "phase-124"
 
 const FLAG_ENV_MAP: Record<PhaseFeatureFlag, string[]> = {
+  "phase-107": ["NEXT_PUBLIC_FEATURE_PHASE_107", "FEATURE_PHASE_107"],
+  "phase-111": ["NEXT_PUBLIC_FEATURE_PHASE_111", "FEATURE_PHASE_111"],
+  "phase-113": ["NEXT_PUBLIC_FEATURE_PHASE_113", "FEATURE_PHASE_113"],
+  "phase-114": ["NEXT_PUBLIC_FEATURE_PHASE_114", "FEATURE_PHASE_114"],
   "phase-116": ["NEXT_PUBLIC_FEATURE_PHASE_116", "FEATURE_PHASE_116"],
   "phase-117": ["NEXT_PUBLIC_FEATURE_PHASE_117", "FEATURE_PHASE_117"],
   "phase-119": ["NEXT_PUBLIC_FEATURE_PHASE_119", "FEATURE_PHASE_119"],
@@ -52,7 +64,7 @@ export function featureFlagEnvKeys(flag: PhaseFeatureFlag): string[] {
 }
 
 export function getEnabledFeatureFlags(): PhaseFeatureFlag[] {
-  const all: PhaseFeatureFlag[] = ["phase-116", "phase-117", "phase-119", "phase-120", "phase-121", "phase-122", "phase-123", "phase-124"]
+  const all: PhaseFeatureFlag[] = ["phase-107", "phase-111", "phase-113", "phase-114", "phase-116", "phase-117", "phase-119", "phase-120", "phase-121", "phase-122", "phase-123", "phase-124"]
   return all.filter(isFeatureEnabled)
 }
 

--- a/lib/narrative-world-store.ts
+++ b/lib/narrative-world-store.ts
@@ -78,6 +78,7 @@ export async function saveNarrativeForToken(
   const store = await readJsonStore<WorldNarrativesStore>(filePath)
   store[String(tokenId)] = { ...data, generated_at: Date.now() }
   await writeJsonStore(filePath, store)
+  invalidateLocalizedNarrativeCache(tokenId)
 }
 
 /** Returns the total count of distinct token narratives across all world collections. */
@@ -137,4 +138,57 @@ export async function getRecentNarrativesForCollection(
     .filter((v) => v.collection_id === collectionId)
     .sort((a, b) => b.generated_at - a.generated_at)
     .slice(0, limit)
+}
+
+// ─── phase-111: localized narrative caching per language pack ──────────────
+// Isolated, flag-gated. Every locale re-fetched the same lore from disk on
+// every request. When enabled, reads are cached per (tokenId, lang) with a
+// short TTL, avoiding redundant JSON-store reads across language packs.
+// When flag off, callers fall back to getNarrativeForToken() directly
+// (zero regression). Rollback: unset NEXT_PUBLIC_FEATURE_PHASE_111 / FEATURE_PHASE_111.
+
+export function isLocalizedCacheEnabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_111 ?? process.env.FEATURE_PHASE_111 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+const LOCALIZED_CACHE_TTL_MS = 5 * 60_000
+
+type LocalizedCacheEntry = {
+  value: WorldNarrativeData | null
+  expiresAt: number
+}
+
+const localizedNarrativeCache = new Map<string, LocalizedCacheEntry>()
+
+function localizedCacheKey(tokenId: number, lang: string): string {
+  return `${tokenId}:${lang}`
+}
+
+/** Drops all cached entries for a token (called after the narrative changes). */
+export function invalidateLocalizedNarrativeCache(tokenId: number): void {
+  for (const key of localizedNarrativeCache.keys()) {
+    if (key.startsWith(`${tokenId}:`)) localizedNarrativeCache.delete(key)
+  }
+}
+
+/**
+ * Reads a token's narrative through a per-(tokenId, lang) cache with a short TTL.
+ * The underlying narrative text is not translated by this cache — it only avoids
+ * redundant store reads when the same locale re-fetches the same lore.
+ * When phase-111 is disabled, bypasses the cache entirely.
+ */
+export async function getNarrativeForTokenCached(
+  tokenId: number,
+  lang: string,
+): Promise<WorldNarrativeData | null> {
+  if (!isLocalizedCacheEnabled()) return getNarrativeForToken(tokenId)
+
+  const key = localizedCacheKey(tokenId, lang)
+  const cached = localizedNarrativeCache.get(key)
+  if (cached && cached.expiresAt > Date.now()) return cached.value
+
+  const value = await getNarrativeForToken(tokenId)
+  localizedNarrativeCache.set(key, { value, expiresAt: Date.now() + LOCALIZED_CACHE_TTL_MS })
+  return value
 }

--- a/lib/notification-store.ts
+++ b/lib/notification-store.ts
@@ -15,6 +15,7 @@ export type NotificationType =
   | "offer_accepted"
   | "offer_rejected"
   | "achievement_unlocked"
+  | "content_takedown"
 
 export type Notification = {
   id: string

--- a/lib/signal-store.ts
+++ b/lib/signal-store.ts
@@ -17,6 +17,9 @@ export type Signal = {
   upvotes: string[]
   created_at: number
   signature: string
+  taken_down?: boolean
+  takedown_reason?: string
+  taken_down_at?: number
 }
 
 export type SignalReply = {
@@ -58,6 +61,9 @@ export async function getSignals(
 ): Promise<Signal[]> {
   const store = await readJsonStore<SignalsStore>(serverDataJsonPath("signals"))
   let items = Object.values(store)
+  if (isModerationEnabled()) {
+    items = items.filter((s) => !s.taken_down)
+  }
   if (channel && channel !== "all") {
     items = items.filter((s) => s.channel === channel)
   }
@@ -139,6 +145,43 @@ export async function getSignalChannelStats(
     channels.push({ id, label, count: counts[id] ?? 0 })
   }
   return channels
+}
+
+// ─── phase-113: narrative content moderation with takedown flow ────────────
+// Isolated, flag-gated. Abusive lore/signals previously had no removal path.
+// When enabled, taken-down signals are excluded from getSignals() listings.
+// When flag off, takedown/restore are no-ops on the read path (zero regression).
+// Rollback: unset NEXT_PUBLIC_FEATURE_PHASE_113 / FEATURE_PHASE_113.
+
+export function isModerationEnabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_113 ?? process.env.FEATURE_PHASE_113 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+/** Marks a signal as taken down. Hidden from getSignals() listings while phase-113 is enabled. */
+export async function takedownSignal(id: string, reason: string): Promise<Signal> {
+  const filePath = serverDataJsonPath("signals")
+  const store = await readJsonStore<SignalsStore>(filePath)
+  const signal = store[id]
+  if (!signal) throw new Error("Signal not found")
+  signal.taken_down = true
+  signal.takedown_reason = reason
+  signal.taken_down_at = Date.now()
+  await writeJsonStore(filePath, store)
+  return signal
+}
+
+/** Reinstates a previously taken-down signal (rollback path). */
+export async function restoreSignal(id: string): Promise<Signal> {
+  const filePath = serverDataJsonPath("signals")
+  const store = await readJsonStore<SignalsStore>(filePath)
+  const signal = store[id]
+  if (!signal) throw new Error("Signal not found")
+  signal.taken_down = false
+  signal.takedown_reason = undefined
+  signal.taken_down_at = undefined
+  await writeJsonStore(filePath, store)
+  return signal
 }
 
 // ─── phase-116: narrative contributor attribution & credit ledger ───────────

--- a/lib/story-arc-continuity.ts
+++ b/lib/story-arc-continuity.ts
@@ -1,0 +1,97 @@
+import { GoogleGenerativeAI, HarmBlockThreshold, HarmCategory } from "@google/generative-ai"
+import { z } from "zod"
+
+// ─── phase-107: AI story-arc continuity validator across artifacts ─────────
+// Isolated, flag-gated. Generated arcs could contradict earlier established
+// lore in the same world with no check. When enabled, a newly generated
+// narrative is checked against the world's most recent narratives using the
+// same Gemini client already wired for narration (app/api/narrator/route.ts).
+// On any config/parse error the check is skipped (fail-open) — it never
+// blocks generation, it only flags an explicit contradiction.
+// When flag off, checkNarrativeContinuity() is not called (zero regression).
+// Rollback: unset NEXT_PUBLIC_FEATURE_PHASE_107 / FEATURE_PHASE_107.
+
+export function isPhase107Enabled(): boolean {
+  const v = (process.env.NEXT_PUBLIC_FEATURE_PHASE_107 ?? process.env.FEATURE_PHASE_107 ?? "").trim().toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+export function flag107RollbackNote(): string {
+  return "Rollback phase-107: unset NEXT_PUBLIC_FEATURE_PHASE_107 / FEATURE_PHASE_107 and restart. No data migration to revert."
+}
+
+const ContinuityCheckResultSchema = z.object({
+  consistent: z.boolean(),
+  reason: z.string().max(400),
+})
+
+export type ContinuityCheckResult = z.infer<typeof ContinuityCheckResultSchema>
+
+function continuityGeminiApiKey(): string | null {
+  const studio = process.env.GOOGLE_AI_STUDIO_API_KEY?.trim().replace(/^["']|["']$/g, "")
+  const legacy = process.env.GEMINI_API_KEY?.trim().replace(/^["']|["']$/g, "")
+  const key = studio?.startsWith("AIza") && studio.length >= 35 ? studio : legacy
+  return key && key.length >= 35 ? key : null
+}
+
+function continuityModelId(): string {
+  const fromEnv = process.env.GEMINI_MODEL?.trim().replace(/^models\//i, "").trim()
+  if (fromEnv && fromEnv.length > 0 && !fromEnv.startsWith("gemini-1.5")) return fromEnv
+  return "gemini-2.0-flash"
+}
+
+const SAFETY_SETTINGS = (
+  [
+    HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+    HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+    HarmCategory.HARM_CATEGORY_HARASSMENT,
+    HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+    HarmCategory.HARM_CATEGORY_CIVIC_INTEGRITY,
+  ] as const
+).map((category) => ({ category, threshold: HarmBlockThreshold.BLOCK_NONE }))
+
+function extractJson(text: string): unknown {
+  const match = text.match(/\{[\s\S]*\}/)
+  return JSON.parse(match ? match[0] : text)
+}
+
+/**
+ * Checks whether a newly generated narrative contradicts the world's most
+ * recent narratives (established lore). Returns null when the flag is off,
+ * the AI client is unconfigured, or the check itself fails — callers should
+ * treat null as "skip check" and proceed, never as a block.
+ */
+export async function checkNarrativeContinuity(
+  worldName: string,
+  newNarrative: string,
+  previousNarratives: string[],
+): Promise<ContinuityCheckResult | null> {
+  if (!isPhase107Enabled()) return null
+  if (previousNarratives.length === 0) return null
+
+  const apiKey = continuityGeminiApiKey()
+  if (!apiKey) return null
+
+  const prompt =
+    `You are a continuity checker for the narrative world "${worldName}". ` +
+    `Established lore (most recent first):\n${previousNarratives.map((n, i) => `${i + 1}. ${n}`).join("\n")}\n\n` +
+    `New artifact narrative to check:\n"${newNarrative}"\n\n` +
+    `Does the new narrative directly contradict a specific fact stated in the established lore ` +
+    `(e.g. a name, event, or outcome asserted differently)? Ignore stylistic or tonal differences. ` +
+    `Respond with ONLY a JSON object, no markdown: {"consistent": boolean, "reason": string}`
+
+  try {
+    const genAI = new GoogleGenerativeAI(apiKey)
+    const model = genAI.getGenerativeModel(
+      { model: continuityModelId(), safetySettings: SAFETY_SETTINGS },
+      { apiVersion: "v1beta" },
+    )
+    const result = await model.generateContent(prompt)
+    const text = result.response.text().trim()
+    const parsed = ContinuityCheckResultSchema.parse(extractJson(text))
+    return parsed
+  } catch {
+    // Fail-open: AI unavailable or response unparseable — never block generation.
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
Implements four Stellar Wave issues as isolated, flag-gated modules with zero regression when each flag is off:
- Timeline visualization for a wallet's world-event history (achievement unlocks), addressing "chronology only expressed as prose"
- Narrative content moderation with a takedown/restore flow for signals, addressing "abusive lore has no removal path"
- Per-locale narrative read caching, addressing "every locale re-fetches untranslated lore"
- An AI story-arc continuity check that runs before a new narrative is saved, addressing "generated arcs contradict earlier established lore" — reuses the existing Gemini client already wired for narration (app/api/narrator/route.ts) rather than adding a new AI integration

## Changes
- `lib/story-arc-continuity.ts` (new): phase-107 — checks a newly generated narrative against a world's recent narratives via the existing Gemini client; fail-open on any config/parse error, only blocks on an explicit detected contradiction. Wired into `POST /api/narrator` (409 `CONTINUITY_CONTRADICTION` on conflict).
- `lib/narrative-world-store.ts`: phase-111 — adds a per-(tokenId, lang) in-memory narrative read cache with a short TTL and cache invalidation on save. Wired into `GET /api/world/narrative/[token_id]` via a new `?lang=` query param.
- `lib/signal-store.ts` + `app/api/signals/[id]/moderate/route.ts` (new): phase-113 — adds takedown/restore fields and functions to `Signal`; taken-down signals are excluded from `getSignals()` listings; new admin-key-gated moderation endpoint notifies the author via a new `content_takedown` notification type (`lib/notification-store.ts`, `components/notifications-modal.tsx`).
- `lib/achievement-store.ts`, `app/api/achievements/route.ts`, `components/profile-panel.tsx`: phase-114 — adds a chronological timeline of achievement unlocks (existing `unlocked_at` timestamps), exposed via a new `timeline` field and rendered in the profile panel's Achievements tab.
- `lib/feature-flags.ts`, `PROJECT_ARCHITECTURE.md`, `docs/TECHNICAL.md`: registers the four new flags (phase-107, phase-111, phase-113, phase-114) following the existing flag registry/documentation pattern, with rollback notes.

## Issues
Resolves #132
Resolves #131
Resolves #129
Resolves #125

## Verification
Manual code review only, per repository policy: `git status`, `git diff --stat`, and the full `git diff` were reviewed end-to-end for each change. Every new code path is isolated behind its own feature flag and falls back to current behavior when the flag is off. `cargo build` and `cargo test` were not run — this is a Next.js/TypeScript project with no cargo target, and no build or test commands were executed as part of this change; verification was manual review only.