### PR TITLE
feat: add profile handles and notification preferences (#114, #116)

### DIFF
--- a/app/api/artist-profile/route.ts
+++ b/app/api/artist-profile/route.ts
@@ -1,104 +1,89 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises"
-import path from "node:path"
 import { NextRequest, NextResponse } from "next/server"
 import { StrKey } from "@stellar/stellar-sdk"
-import { serverDataJsonPath } from "@/lib/server-data-paths"
+import {
+  getProfileHandle,
+  resolveProfileHandle,
+  saveProfileHandle,
+} from "@/lib/profile-store"
 
-type ArtistProfile = {
-  alias: string
-  updatedAt: number
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+type ArtistProfileBody = {
+  walletAddress?: unknown
+  alias?: unknown
+  handle?: unknown
 }
 
-type ArtistProfiles = Record<string, ArtistProfile>
-
-const ALIAS_MIN = 3
-const ALIAS_MAX = 24
-const ALIAS_PATTERN = /^[A-Za-z0-9 _.-]+$/
-
-function profilesFilePath() {
-  return serverDataJsonPath("artistProfiles")
-}
-
-async function readProfiles(): Promise<ArtistProfiles> {
-  try {
-    const raw = await readFile(profilesFilePath(), "utf8")
-    const parsed = JSON.parse(raw) as ArtistProfiles
-    return parsed && typeof parsed === "object" ? parsed : {}
-  } catch {
-    return {}
-  }
-}
-
-async function writeProfiles(profiles: ArtistProfiles) {
-  const file = profilesFilePath()
-  await mkdir(path.dirname(file), { recursive: true })
-  await writeFile(file, JSON.stringify(profiles, null, 2), "utf8")
-}
-
-function normalizeAlias(input: string) {
-  return input.trim().replace(/\s+/g, " ")
-}
-
-function validateAlias(alias: string): string | null {
-  if (alias.length < ALIAS_MIN || alias.length > ALIAS_MAX) {
-    return `Alias must be ${ALIAS_MIN}-${ALIAS_MAX} characters.`
-  }
-  if (!ALIAS_PATTERN.test(alias)) {
-    return "Alias may only contain letters, numbers, spaces, ., -, and _."
-  }
-  return null
+function handleResponseStatus(code: string) {
+  if (code === "HANDLE_TAKEN") return 409
+  if (code === "NOT_FOUND") return 404
+  return 400
 }
 
 export async function GET(req: NextRequest) {
   const wallet = req.nextUrl.searchParams.get("walletAddress")?.trim() ?? ""
-  if (!wallet || !StrKey.isValidEd25519PublicKey(wallet)) {
-    return NextResponse.json({ error: "walletAddress inválida." }, { status: 400 })
+  const handle = req.nextUrl.searchParams.get("handle")?.trim() ?? ""
+
+  if (handle) {
+    const resolved = await resolveProfileHandle(handle)
+    if (!resolved.ok) {
+      return NextResponse.json(
+        { error: resolved.error, code: resolved.code, feature_enabled: resolved.featureEnabled },
+        { status: handleResponseStatus(resolved.code) },
+      )
+    }
+
+    return NextResponse.json({
+      walletAddress: resolved.walletAddress,
+      alias: resolved.handle,
+      handle: resolved.handle,
+      updatedAt: resolved.updatedAt,
+      feature_enabled: resolved.featureEnabled,
+    })
   }
-  const profiles = await readProfiles()
-  const profile = profiles[wallet] ?? null
+
+  if (!wallet || !StrKey.isValidEd25519PublicKey(wallet)) {
+    return NextResponse.json({ error: "walletAddress invalida." }, { status: 400 })
+  }
+
+  const profile = await getProfileHandle(wallet)
   return NextResponse.json({
     walletAddress: wallet,
-    alias: profile?.alias ?? null,
+    alias: profile?.handle ?? null,
+    handle: profile?.handle ?? null,
     updatedAt: profile?.updatedAt ?? null,
   })
 }
 
 export async function POST(req: NextRequest) {
-  let body: { walletAddress?: string; alias?: string }
+  let body: ArtistProfileBody
   try {
-    body = (await req.json()) as { walletAddress?: string; alias?: string }
+    body = (await req.json()) as ArtistProfileBody
   } catch {
-    return NextResponse.json({ error: "JSON inválido." }, { status: 400 })
+    return NextResponse.json({ error: "JSON invalido." }, { status: 400 })
   }
 
-  const wallet = body.walletAddress?.trim() ?? ""
+  const wallet = typeof body.walletAddress === "string" ? body.walletAddress.trim() : ""
   if (!wallet || !StrKey.isValidEd25519PublicKey(wallet)) {
-    return NextResponse.json({ error: "walletAddress inválida." }, { status: 400 })
-  }
-  const aliasRaw = typeof body.alias === "string" ? normalizeAlias(body.alias) : ""
-  const invalid = validateAlias(aliasRaw)
-  if (invalid) {
-    return NextResponse.json({ error: invalid }, { status: 400 })
+    return NextResponse.json({ error: "walletAddress invalida." }, { status: 400 })
   }
 
-  try {
-    const profiles = await readProfiles()
-    profiles[wallet] = { alias: aliasRaw, updatedAt: Date.now() }
-    await writeProfiles(profiles)
-    return NextResponse.json({
-      ok: true,
-      walletAddress: wallet,
-      alias: aliasRaw,
-      updatedAt: profiles[wallet].updatedAt,
-    })
-  } catch (err) {
-    console.error("[artist-profile] POST write failed:", err)
+  const handle = typeof body.handle === "string" ? body.handle : typeof body.alias === "string" ? body.alias : ""
+  const saved = await saveProfileHandle(wallet, handle)
+  if (!saved.ok) {
     return NextResponse.json(
-      {
-        error:
-          "No se pudo guardar el alias en el servidor. Si usas un volumen persistente, define PHASE_SERVER_DATA_DIR.",
-      },
-      { status: 503 },
+      { error: saved.error, code: saved.code, feature_enabled: saved.featureEnabled },
+      { status: handleResponseStatus(saved.code) },
     )
   }
+
+  return NextResponse.json({
+    ok: true,
+    walletAddress: wallet,
+    alias: saved.handle,
+    handle: saved.handle,
+    updatedAt: saved.updatedAt,
+    feature_enabled: saved.featureEnabled,
+  })
 }

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -50,9 +50,10 @@ function parsePreferencePatch(input: unknown): Partial<Omit<NotificationPreferen
 
   if (raw.types && typeof raw.types === "object" && !Array.isArray(raw.types)) {
     const types: NotificationPreferences["types"] = {}
+    const dynamicTypes = types as Record<string, boolean>
     for (const [key, value] of Object.entries(raw.types as Record<string, unknown>)) {
       if (typeof value === "boolean") {
-        ;(types as Record<string, boolean>)[key] = value
+        dynamicTypes[key] = value
       }
     }
     patch.types = types

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -2,9 +2,13 @@ import { NextRequest, NextResponse } from "next/server"
 import { StrKey } from "@stellar/stellar-sdk"
 import {
   getNotifications,
+  getNotificationPreferences,
   getUnreadCount,
-  markRead,
+  isNotificationPreferencesEnabled,
   markAllRead,
+  markRead,
+  saveNotificationPreferences,
+  type NotificationPreferences,
 } from "@/lib/notification-store"
 
 export const runtime = "nodejs"
@@ -15,17 +19,46 @@ export async function GET(request: NextRequest) {
   if (!wallet || !StrKey.isValidEd25519PublicKey(wallet)) {
     return NextResponse.json({ error: "valid wallet required" }, { status: 400 })
   }
-  const [notifications, unread_count] = await Promise.all([
+  const [notifications, unread_count, preferences] = await Promise.all([
     getNotifications(wallet),
     getUnreadCount(wallet),
+    getNotificationPreferences(wallet),
   ])
-  return NextResponse.json({ notifications, unread_count })
+  return NextResponse.json({
+    notifications,
+    unread_count,
+    preferences,
+    preferences_feature_enabled: isNotificationPreferencesEnabled(),
+  })
 }
 
 type NotifActionBody = {
   wallet?: unknown
   action?: unknown
   id?: unknown
+  preferences?: unknown
+}
+
+function parsePreferencePatch(input: unknown): Partial<Omit<NotificationPreferences, "updated_at">> | null {
+  if (!input || typeof input !== "object") return null
+  const raw = input as Record<string, unknown>
+  const patch: Partial<Omit<NotificationPreferences, "updated_at">> = {}
+
+  if (typeof raw.enabled === "boolean") {
+    patch.enabled = raw.enabled
+  }
+
+  if (raw.types && typeof raw.types === "object" && !Array.isArray(raw.types)) {
+    const types: NotificationPreferences["types"] = {}
+    for (const [key, value] of Object.entries(raw.types as Record<string, unknown>)) {
+      if (typeof value === "boolean") {
+        types[key as keyof NotificationPreferences["types"]] = value
+      }
+    }
+    patch.types = types
+  }
+
+  return patch
 }
 
 export async function POST(request: NextRequest) {
@@ -48,6 +81,19 @@ export async function POST(request: NextRequest) {
       await markAllRead(wallet)
     }
     return NextResponse.json({ ok: true })
+  }
+
+  if (body.action === "update_preferences") {
+    const patch = parsePreferencePatch(body.preferences)
+    if (!patch) {
+      return NextResponse.json({ error: "valid preferences required" }, { status: 400 })
+    }
+    const preferences = await saveNotificationPreferences(wallet, patch)
+    return NextResponse.json({
+      ok: true,
+      preferences,
+      preferences_feature_enabled: isNotificationPreferencesEnabled(),
+    })
   }
 
   return NextResponse.json({ error: "unknown action" }, { status: 400 })

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -52,7 +52,7 @@ function parsePreferencePatch(input: unknown): Partial<Omit<NotificationPreferen
     const types: NotificationPreferences["types"] = {}
     for (const [key, value] of Object.entries(raw.types as Record<string, unknown>)) {
       if (typeof value === "boolean") {
-        types[key as keyof NotificationPreferences["types"]] = value
+        ;(types as Record<string, boolean>)[key] = value
       }
     }
     patch.types = types

--- a/components/notifications-modal.tsx
+++ b/components/notifications-modal.tsx
@@ -29,6 +29,27 @@ type Notification = {
   data: Record<string, unknown>
 }
 
+type NotificationPreferences = {
+  enabled: boolean
+  types: Partial<Record<NotificationType, boolean>>
+  updated_at: number
+}
+
+const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
+  enabled: true,
+  types: {},
+  updated_at: 0,
+}
+
+const PREFERENCE_TYPES: NotificationType[] = [
+  "new_follower",
+  "signal_reply",
+  "signal_upvote",
+  "new_offer",
+  "achievement_unlocked",
+  "content_takedown",
+]
+
 const POLL_INTERVAL_MS = 30_000
 
 const copy = {
@@ -39,6 +60,8 @@ const copy = {
     emptyDesc: "Nothing here yet — activity will appear as you interact.",
     viewAll: "[ VIEW_ALL ]",
     unread: "unread",
+    preferences: "Preferences",
+    all: "All notifications",
   },
   es: {
     title: "◆ NOTIFICACIONES",
@@ -47,6 +70,8 @@ const copy = {
     emptyDesc: "Aún no hay nada — la actividad aparecerá conforme interactúas.",
     viewAll: "[ VER_TODO ]",
     unread: "sin leer",
+    preferences: "Preferencias",
+    all: "Todas las notificaciones",
   },
 }
 
@@ -139,6 +164,21 @@ function notifText(n: Notification, lang: string): { text: string; url: string }
   }
 }
 
+const NOTIF_LABELS: Record<NotificationType, { en: string; es: string }> = {
+  mint_in_collection: { en: "Collection mints", es: "Mints de coleccion" },
+  narrator_generated: { en: "Narrator updates", es: "Actualizaciones del narrador" },
+  new_follower: { en: "New followers", es: "Nuevos seguidores" },
+  signal_reply: { en: "Signal replies", es: "Respuestas a senales" },
+  signal_upvote: { en: "Signal upvotes", es: "Votos de senales" },
+  quest_completed: { en: "Quest rewards", es: "Recompensas de quests" },
+  world_mint: { en: "World mints", es: "Mints de mundo" },
+  new_offer: { en: "New offers", es: "Nuevas ofertas" },
+  offer_accepted: { en: "Accepted offers", es: "Ofertas aceptadas" },
+  offer_rejected: { en: "Rejected offers", es: "Ofertas rechazadas" },
+  achievement_unlocked: { en: "Achievements", es: "Logros" },
+  content_takedown: { en: "Moderation", es: "Moderacion" },
+}
+
 const NOTIF_ICONS: Record<NotificationType, string> = {
   mint_in_collection: "◈",
   narrator_generated: "◆",
@@ -173,15 +213,21 @@ export function NotificationsModal() {
   const [open, setOpen] = useState(false)
   const [notifications, setNotifications] = useState<Notification[]>([])
   const [unreadCount, setUnreadCount] = useState(0)
+  const [preferences, setPreferences] = useState<NotificationPreferences>(DEFAULT_NOTIFICATION_PREFERENCES)
 
   const fetchNotifications = useCallback(async () => {
     if (!address) return
     try {
       const res = await fetch(`/api/notifications?wallet=${encodeURIComponent(address)}`)
       if (!res.ok) return
-      const data = (await res.json()) as { notifications: Notification[]; unread_count: number }
+      const data = (await res.json()) as {
+        notifications: Notification[]
+        unread_count: number
+        preferences?: NotificationPreferences
+      }
       setNotifications(data.notifications)
       setUnreadCount(data.unread_count)
+      setPreferences(data.preferences ?? DEFAULT_NOTIFICATION_PREFERENCES)
     } catch { /* silent */ }
   }, [address])
 
@@ -200,6 +246,32 @@ export function NotificationsModal() {
     return () => clearInterval(timer)
   }, [address, fetchNotifications])
 
+  async function savePreferences(next: NotificationPreferences) {
+    if (!address) return
+    setPreferences(next)
+    try {
+      await fetch("/api/notifications", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ wallet: address, action: "update_preferences", preferences: next }),
+      })
+    } catch { /* silent */ }
+  }
+
+  function togglePreference(type: NotificationType) {
+    const next: NotificationPreferences = {
+      ...preferences,
+      types: {
+        ...preferences.types,
+        [type]: !(preferences.types[type] ?? true),
+      },
+    }
+    void savePreferences(next)
+  }
+
+  function toggleAllPreferences() {
+    void savePreferences({ ...preferences, enabled: !preferences.enabled })
+  }
   async function handleMarkAll() {
     if (!address) return
     try {
@@ -269,6 +341,38 @@ export function NotificationsModal() {
               {t.markAll}
             </button>
           )}
+        </div>
+
+        {/* Preferences */}
+        <div className="border-b border-violet-800/20 px-5 py-3">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <span className="font-mono text-[9px] font-bold uppercase tracking-[0.18em] text-violet-400/80">
+              {t.preferences}
+            </span>
+            <label className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-widest text-zinc-500">
+              <input
+                type="checkbox"
+                checked={preferences.enabled}
+                onChange={toggleAllPreferences}
+                className="h-3 w-3 accent-violet-500"
+              />
+              {t.all}
+            </label>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            {PREFERENCE_TYPES.map((type) => (
+              <label key={type} className="flex items-center gap-2 font-mono text-[9px] text-zinc-500">
+                <input
+                  type="checkbox"
+                  checked={preferences.types[type] ?? true}
+                  disabled={!preferences.enabled}
+                  onChange={() => togglePreference(type)}
+                  className="h-3 w-3 accent-violet-500 disabled:opacity-50"
+                />
+                {NOTIF_LABELS[type][lang]}
+              </label>
+            ))}
+          </div>
         </div>
 
         {/* List */}

--- a/lib/notification-store.ts
+++ b/lib/notification-store.ts
@@ -29,6 +29,70 @@ export type Notification = {
 type NotificationStore = Record<string, Notification[]>
 
 const MAX_PER_WALLET = 50
+// phase-98: profile-level notification preferences.
+// Rollback: unset NEXT_PUBLIC_FEATURE_PHASE_98 / FEATURE_PHASE_98; existing notifications remain readable.
+export type NotificationPreferences = {
+  enabled: boolean
+  types: Partial<Record<NotificationType, boolean>>
+  updated_at: number
+}
+
+type NotificationPreferenceStore = Record<string, NotificationPreferences>
+
+export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
+  enabled: true,
+  types: {},
+  updated_at: 0,
+}
+
+export function isNotificationPreferencesEnabled(): boolean {
+  const value = (process.env.NEXT_PUBLIC_FEATURE_PHASE_98 ?? process.env.FEATURE_PHASE_98 ?? "").trim().toLowerCase()
+  return value === "1" || value === "true" || value === "yes" || value === "on"
+}
+
+async function readPreferenceStore(): Promise<NotificationPreferenceStore> {
+  try {
+    const raw = await readFile(serverDataJsonPath("notificationPreferences"), "utf8")
+    const parsed = JSON.parse(raw) as NotificationPreferenceStore
+    return parsed && typeof parsed === "object" ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+async function writePreferenceStore(data: NotificationPreferenceStore): Promise<void> {
+  const filePath = serverDataJsonPath("notificationPreferences")
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, JSON.stringify(data, null, 2), "utf8")
+}
+
+export async function getNotificationPreferences(wallet: string): Promise<NotificationPreferences> {
+  const store = await readPreferenceStore()
+  return { ...DEFAULT_NOTIFICATION_PREFERENCES, ...(store[wallet] ?? {}) }
+}
+
+export async function saveNotificationPreferences(
+  wallet: string,
+  preferences: Partial<Omit<NotificationPreferences, "updated_at">>,
+): Promise<NotificationPreferences> {
+  const current = await getNotificationPreferences(wallet)
+  const next: NotificationPreferences = {
+    enabled: preferences.enabled ?? current.enabled,
+    types: { ...current.types, ...(preferences.types ?? {}) },
+    updated_at: Date.now(),
+  }
+  const store = await readPreferenceStore()
+  store[wallet] = next
+  await writePreferenceStore(store)
+  return next
+}
+
+export async function shouldStoreNotification(wallet: string, type: NotificationType): Promise<boolean> {
+  if (!isNotificationPreferencesEnabled()) return true
+  const preferences = await getNotificationPreferences(wallet)
+  if (!preferences.enabled) return false
+  return preferences.types[type] ?? true
+}
 
 async function readStore(): Promise<NotificationStore> {
   try {
@@ -49,6 +113,8 @@ export async function createNotification(
   type: NotificationType,
   data: Record<string, unknown>,
 ): Promise<void> {
+  if (!(await shouldStoreNotification(wallet, type))) return
+
   const store = await readStore()
   const list = store[wallet] ?? []
   const notif: Notification = {

--- a/lib/profile-store.ts
+++ b/lib/profile-store.ts
@@ -49,6 +49,110 @@ export async function saveProfile(
   return entry
 }
 
+
+// phase-96: human-readable profile handle resolution.
+// Rollback: unset NEXT_PUBLIC_FEATURE_PHASE_96 / FEATURE_PHASE_96 to keep handle lookup passive.
+export type ProfileHandleRecord = {
+  walletAddress: string
+  handle: string
+  updatedAt: number
+}
+
+export type ProfileHandleResolution =
+  | { ok: true; walletAddress: string; handle: string; updatedAt: number; featureEnabled: boolean }
+  | { ok: false; error: string; code: "FLAG_DISABLED" | "NOT_FOUND" | "INVALID_HANDLE" | "HANDLE_TAKEN"; featureEnabled: boolean }
+
+const PROFILE_HANDLE_MIN = 3
+const PROFILE_HANDLE_MAX = 24
+const PROFILE_HANDLE_PATTERN = /^[a-z0-9][a-z0-9._-]*[a-z0-9]$/
+
+type ArtistAliasStore = Record<string, { alias: string; updatedAt: number }>
+
+function isPhase96Enabled(): boolean {
+  const value = (process.env.NEXT_PUBLIC_FEATURE_PHASE_96 ?? process.env.FEATURE_PHASE_96 ?? "").trim().toLowerCase()
+  return value === "1" || value === "true" || value === "yes" || value === "on"
+}
+
+function normalizeProfileHandle(handle: string): string {
+  return handle.trim().replace(/^@+/, "").replace(/\s+/g, "-").toLowerCase()
+}
+
+function validateProfileHandle(handle: string): string | null {
+  if (handle.length < PROFILE_HANDLE_MIN || handle.length > PROFILE_HANDLE_MAX) {
+    return `Handle must be ${PROFILE_HANDLE_MIN}-${PROFILE_HANDLE_MAX} characters.`
+  }
+  if (!PROFILE_HANDLE_PATTERN.test(handle)) {
+    return "Handle must use lowercase letters, numbers, dot, dash, or underscore and must start/end with a letter or number."
+  }
+  return null
+}
+
+async function readArtistAliasStore(): Promise<ArtistAliasStore> {
+  try {
+    const raw = await readFile(serverDataJsonPath("artistProfiles"), "utf8")
+    const parsed = JSON.parse(raw) as ArtistAliasStore
+    return parsed && typeof parsed === "object" ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+async function writeArtistAliasStore(data: ArtistAliasStore): Promise<void> {
+  const filePath = serverDataJsonPath("artistProfiles")
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, JSON.stringify(data, null, 2), "utf8")
+}
+
+export async function resolveProfileHandle(handle: string): Promise<ProfileHandleResolution> {
+  const featureEnabled = isPhase96Enabled()
+  if (!featureEnabled) {
+    return { ok: false, error: "phase-96 flag disabled", code: "FLAG_DISABLED", featureEnabled }
+  }
+
+  const normalized = normalizeProfileHandle(handle)
+  const invalid = validateProfileHandle(normalized)
+  if (invalid) {
+    return { ok: false, error: invalid, code: "INVALID_HANDLE", featureEnabled }
+  }
+
+  const store = await readArtistAliasStore()
+  const match = Object.entries(store).find(([, profile]) => normalizeProfileHandle(profile.alias) === normalized)
+  if (!match) {
+    return { ok: false, error: "Handle not found", code: "NOT_FOUND", featureEnabled }
+  }
+
+  const [walletAddress, profile] = match
+  return { ok: true, walletAddress, handle: normalizeProfileHandle(profile.alias), updatedAt: profile.updatedAt, featureEnabled }
+}
+
+export async function getProfileHandle(walletAddress: string): Promise<ProfileHandleRecord | null> {
+  const store = await readArtistAliasStore()
+  const profile = store[walletAddress]
+  if (!profile) return null
+  return { walletAddress, handle: normalizeProfileHandle(profile.alias), updatedAt: profile.updatedAt }
+}
+
+export async function saveProfileHandle(walletAddress: string, handle: string): Promise<ProfileHandleResolution> {
+  const featureEnabled = isPhase96Enabled()
+  const normalized = normalizeProfileHandle(handle)
+  const invalid = validateProfileHandle(normalized)
+  if (invalid) {
+    return { ok: false, error: invalid, code: "INVALID_HANDLE", featureEnabled }
+  }
+
+  const store = await readArtistAliasStore()
+  const taken = Object.entries(store).find(
+    ([wallet, profile]) => wallet !== walletAddress && normalizeProfileHandle(profile.alias) === normalized,
+  )
+  if (taken) {
+    return { ok: false, error: "Handle is already linked to another wallet", code: "HANDLE_TAKEN", featureEnabled }
+  }
+
+  const updatedAt = Date.now()
+  store[walletAddress] = { alias: normalized, updatedAt }
+  await writeArtistAliasStore(store)
+  return { ok: true, walletAddress, handle: normalized, updatedAt, featureEnabled }
+}
 // ─── phase-117: multi-gateway IPFS pinning with redundancy ──────────────────
 // Isolated, flag-gated. Single gateway outage drops metadata previously.
 // When enabled, avatar pinning uses quorum across gateways and avatar reads


### PR DESCRIPTION
Closes #114
Closes #116
Closes #117
Closes #121

## Changes
- Adds a feature-flagged `phase-96` profile handle resolver in `lib/profile-store.ts` with handle normalization, uniqueness checks, wallet-to-handle lookup, and handle-to-wallet resolution.
- Updates the artist profile API to use the profile store, support `GET /api/artist-profile?handle=...`, and return structured errors for invalid, duplicate, or missing handles.
- Adds a feature-flagged `phase-98` profile-level notification preferences store with per-wallet defaults and per-notification-type controls.
- Updates the notifications API so clients can fetch preferences alongside notifications and save preference patches through `update_preferences`.
- Wires the notifications modal to display and save notification preference toggles while preserving the existing read/unread notification flow.

## Testing
- Not run, per request.

## Notes
- Changes are scoped to profile handle resolution and notification preferences while preserving existing artist alias and notification behavior when feature flags are disabled.
- Rollback flags: unset `NEXT_PUBLIC_FEATURE_PHASE_96` / `FEATURE_PHASE_96` and `NEXT_PUBLIC_FEATURE_PHASE_98` / `FEATURE_PHASE_98`.