### PR TITLE
Add locale preferences to profile schema

### DIFF
--- a/app/api/profile/avatar/route.ts
+++ b/app/api/profile/avatar/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest } from "next/server"
-import { getProfile, isProfilePinningRedundancyEnabled, resolveAvatarWithFallback } from "@/lib/profile-store"
+import { DEFAULT_PROFILE_LOCALE, getProfile, isProfilePinningRedundancyEnabled, localizeAvatarName, normalizeProfileLocale, resolveAvatarWithFallback } from "@/lib/profile-store"
 import { StrKey } from "@stellar/stellar-sdk"
 import { createApiRequestContext } from "@/lib/api-observability"
 import { z } from "zod"
 
 export const dynamic = "force-dynamic"
 
-// ─── phase-117: multi-gateway redundancy ────────────────────────────────────
+// ??? phase-117: multi-gateway redundancy ????????????????????????????????????
 // Single gateway outage previously dropped metadata. When flag enabled, avatar
 // reads use gateway rotation + checksum verification; pins require quorum.
 
@@ -34,6 +34,8 @@ export async function GET(request: NextRequest) {
       return api.json({ avatar: null }, { event: "profile.avatar.empty", metadata: { wallet } })
     }
 
+    const preferredLocale = normalizeProfileLocale(profile.locale) ?? DEFAULT_PROFILE_LOCALE
+
     // phase-117: when enabled, rewrite image URL through verified gateway fallback
     let imageOut = profile.avatar_image_url ?? ""
     let gatewayMeta: string | null = null
@@ -54,7 +56,8 @@ export async function GET(request: NextRequest) {
         avatar: {
           tokenId: profile.avatar_token_id,
           image: imageOut,
-          name: `Phase Artifact #${profile.avatar_token_id}`,
+          name: localizeAvatarName(profile.avatar_token_id, preferredLocale),
+          locale: preferredLocale,
         },
         ...(isProfilePinningRedundancyEnabled()
           ? { redundancy: { enabled: true, gateway: gatewayMeta ?? "legacy" } }
@@ -67,9 +70,11 @@ export async function GET(request: NextRequest) {
           token_id: profile.avatar_token_id,
           ...(gatewayMeta ? { gateway: gatewayMeta } : {}),
           phase117: isProfilePinningRedundancyEnabled(),
+          locale: preferredLocale,
         },
         headers: {
           "Cache-Control": "private, max-age=30",
+          "X-Phase-Locale": preferredLocale,
           ...(isProfilePinningRedundancyEnabled() ? { "X-Phase117": "enabled", ...(gatewayMeta ? { "X-Phase-Gateway": gatewayMeta } : {}) } : {}),
         },
       },
@@ -79,7 +84,7 @@ export async function GET(request: NextRequest) {
   }
 }
 
-// POST — pin avatar with redundancy (phase-117 gated)
+// POST ? pin avatar with redundancy (phase-117 gated)
 // Preserves existing GET; adds opt-in pin path for clients that want quorum
 export async function POST(request: NextRequest) {
   const api = createApiRequestContext(request, "/api/profile/avatar")

--- a/components/wallet-avatar.tsx
+++ b/components/wallet-avatar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react"
 
-// ─── phase-117: multi-gateway fallback client wiring ────────────────────────
+// ??? phase-117: multi-gateway fallback client wiring ????????????????????????
 // Preserves original lazy-load + initials fallback. When an image fails,
 // tries alternate gateways for the same CID (redundancy).
 
@@ -34,6 +34,7 @@ type AvatarData = {
   tokenId: number
   image?: string
   name: string
+  locale?: string
 }
 
 function getInitials(wallet: string, displayName?: string): string {
@@ -141,7 +142,7 @@ export function WalletAvatar({
         ref={ref}
         className={`shrink-0 rounded-full overflow-hidden border border-violet-700/40 ${className}`}
         style={{ width: size, height: size }}
-        title={avatar?.name}
+        title={avatar?.locale ? `${avatar.name} (${avatar.locale})` : avatar?.name}
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img

--- a/lib/__tests__/profile-locale.test.ts
+++ b/lib/__tests__/profile-locale.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "node:test"
+import * as assert from "node:assert/strict"
+import {
+  DEFAULT_PROFILE_LOCALE,
+  localizeAvatarName,
+  normalizeProfileLocale,
+  resolveProfileLocale,
+} from "@/lib/profile-store"
+
+describe("phase-102 profile locale preferences", () => {
+  it("normalizes supported locale tags case-insensitively", () => {
+    assert.equal(normalizeProfileLocale("pt-br"), "pt-BR")
+    assert.equal(normalizeProfileLocale("YO"), "yo")
+    assert.equal(normalizeProfileLocale("unknown"), null)
+  })
+
+  it("guards locale resolution behind the phase-102 feature flag", () => {
+    process.env.FEATURE_PHASE_102 = ""
+    const disabled = resolveProfileLocale("fr")
+    assert.equal(disabled.ok, false)
+    assert.equal(disabled.locale, DEFAULT_PROFILE_LOCALE)
+
+    process.env.FEATURE_PHASE_102 = "1"
+    const enabled = resolveProfileLocale("fr")
+    assert.equal(enabled.ok, true)
+    assert.equal(enabled.locale, "fr")
+    process.env.FEATURE_PHASE_102 = ""
+  })
+
+  it("localizes avatar display names with a safe English fallback", () => {
+    assert.equal(localizeAvatarName(42, "es"), "Artefacto Phase #42")
+    assert.equal(localizeAvatarName(7), "Phase Artifact #7")
+  })
+})

--- a/lib/profile-store.ts
+++ b/lib/profile-store.ts
@@ -10,6 +10,7 @@ export type ProfileData = {
   telegram?: string
   avatar_token_id?: number
   avatar_image_url?: string
+  locale?: ProfileLocale
   updated_at: number
 }
 
@@ -50,6 +51,69 @@ export async function saveProfile(
 }
 
 
+// phase-102: locale preference support for profile localization.
+// Rollback: unset NEXT_PUBLIC_FEATURE_PHASE_102 / FEATURE_PHASE_102 to keep default English presentation.
+export const SUPPORTED_PROFILE_LOCALES = ["en", "es", "fr", "pt-BR", "yo", "ig"] as const
+export type ProfileLocale = (typeof SUPPORTED_PROFILE_LOCALES)[number]
+export const DEFAULT_PROFILE_LOCALE: ProfileLocale = "en"
+
+export type ProfileLocaleResolution =
+  | { ok: true; locale: ProfileLocale; featureEnabled: boolean }
+  | { ok: false; locale: ProfileLocale; error: string; code: "FLAG_DISABLED" | "UNSUPPORTED_LOCALE"; featureEnabled: boolean }
+
+export function isPhase102Enabled(): boolean {
+  const value = (process.env.NEXT_PUBLIC_FEATURE_PHASE_102 ?? process.env.FEATURE_PHASE_102 ?? "").trim().toLowerCase()
+  return value === "1" || value === "true" || value === "yes" || value === "on"
+}
+
+export function normalizeProfileLocale(locale: string | null | undefined): ProfileLocale | null {
+  const normalized = (locale ?? "").trim()
+  const match = SUPPORTED_PROFILE_LOCALES.find((candidate) => candidate.toLowerCase() === normalized.toLowerCase())
+  return match ?? null
+}
+
+export function resolveProfileLocale(locale: string | null | undefined): ProfileLocaleResolution {
+  const featureEnabled = isPhase102Enabled()
+  if (!featureEnabled) {
+    return { ok: false, locale: DEFAULT_PROFILE_LOCALE, error: "phase-102 flag disabled", code: "FLAG_DISABLED", featureEnabled }
+  }
+
+  const normalized = normalizeProfileLocale(locale)
+  if (!normalized) {
+    return { ok: false, locale: DEFAULT_PROFILE_LOCALE, error: "Unsupported profile locale", code: "UNSUPPORTED_LOCALE", featureEnabled }
+  }
+
+  return { ok: true, locale: normalized, featureEnabled }
+}
+
+export function localizeAvatarName(tokenId: number, locale: ProfileLocale = DEFAULT_PROFILE_LOCALE): string {
+  const labels: Record<ProfileLocale, string> = {
+    en: "Phase Artifact",
+    es: "Artefacto Phase",
+    fr: "Artefact Phase",
+    "pt-BR": "Artefato Phase",
+    yo: "Ohun Iranti Phase",
+    ig: "Ihe Ncheta Phase",
+  }
+  return `${labels[locale] ?? labels.en} #${tokenId}`
+}
+
+export async function getProfileLocalePreference(wallet: string): Promise<ProfileLocale> {
+  const profile = await getProfile(wallet)
+  return normalizeProfileLocale(profile?.locale) ?? DEFAULT_PROFILE_LOCALE
+}
+
+export async function saveProfileLocalePreference(wallet: string, locale: string): Promise<ProfileLocaleResolution> {
+  const resolved = resolveProfileLocale(locale)
+  if (!resolved.ok) return resolved
+
+  const profile = await getProfile(wallet)
+  await saveProfile(wallet, {
+    ...(profile ?? {}),
+    locale: resolved.locale,
+  })
+  return resolved
+}
 // phase-96: human-readable profile handle resolution.
 // Rollback: unset NEXT_PUBLIC_FEATURE_PHASE_96 / FEATURE_PHASE_96 to keep handle lookup passive.
 export type ProfileHandleRecord = {
@@ -153,7 +217,7 @@ export async function saveProfileHandle(walletAddress: string, handle: string): 
   await writeArtistAliasStore(store)
   return { ok: true, walletAddress, handle: normalized, updatedAt, featureEnabled }
 }
-// ─── phase-117: multi-gateway IPFS pinning with redundancy ──────────────────
+// ??? phase-117: multi-gateway IPFS pinning with redundancy ??????????????????
 // Isolated, flag-gated. Single gateway outage drops metadata previously.
 // When enabled, avatar pinning uses quorum across gateways and avatar reads
 // try fallback gateways with checksum verification. When flag off, legacy
@@ -193,7 +257,7 @@ export async function pinAvatarWithRedundancy(
   opts: { quorum?: number; fileName?: string; expectedChecksum?: string | null } = {},
 ): Promise<AvatarPinResult> {
   if (!isProfilePinningRedundancyEnabled()) {
-    // legacy: single pin via /api/ipfs style — return not-enabled code
+    // legacy: single pin via /api/ipfs style ? return not-enabled code
     return { ok: false, error: "phase-117 flag disabled (set NEXT_PUBLIC_FEATURE_PHASE_117=1)", code: "FLAG_DISABLED" }
   }
   const jwt = (process.env.PINATA_JWT ?? process.env.PINATA_API_JWT ?? "").trim()


### PR DESCRIPTION
Closes #115
Closes #119
Closes #120
Closes #143

## Changes
- add phase-102 gated profile locale preference helpers with normalization and structured errors
- persist locale on profile records and expose helpers for reading/saving locale preferences
- localize avatar API display names based on stored locale preference
- pass locale metadata through the wallet avatar response shape
- add focused locale helper coverage

## Testing
- Not run, per request.