### PR TITLE
Add phase-gated metadata, gateway, analytics, and dedup safeguards

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
+import { createHash } from "node:crypto"
 import {
   fetchPhaseProtocolTotalSupply,
   fetchTokenOwnerAddress,
@@ -7,6 +8,7 @@ import {
 import { buildPhaseTokenMetadataJson } from "@/lib/phase-nft-metadata-build"
 import { extractBaseAddress } from "@stellar/stellar-sdk"
 import { getAllWorldCollections } from "@/lib/narrative-world-store"
+import { isFeatureEnabled } from "@/lib/feature-flags"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -25,6 +27,8 @@ export type ExploreItem = {
   tokenId: number
   name: string
   image: string
+  contentHash?: string
+  duplicateOfTokenId?: number
   collectionId: number | null
   ownerTruncated: string
   worldName?: string
@@ -52,6 +56,27 @@ async function mapConcurrent<T, R>(
   }
   await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker))
   return out
+}
+
+export function assetContentHash(item: Pick<ExploreItem, "image">): string | null {
+  const image = item.image.trim().toLowerCase()
+  if (!image) return null
+  return createHash("sha256").update(image, "utf8").digest("hex")
+}
+
+export function dedupeExploreItems(items: ExploreItem[]): ExploreItem[] {
+  if (!isFeatureEnabled("phase-127")) return items
+  const firstByHash = new Map<string, number>()
+  return items.map((item) => {
+    const contentHash = assetContentHash(item)
+    if (!contentHash) return item
+    const firstTokenId = firstByHash.get(contentHash)
+    if (firstTokenId === undefined) {
+      firstByHash.set(contentHash, item.tokenId)
+      return { ...item, contentHash }
+    }
+    return { ...item, contentHash, duplicateOfTokenId: firstTokenId }
+  })
 }
 
 export async function GET(request: NextRequest) {
@@ -130,7 +155,7 @@ export async function GET(request: NextRequest) {
     const filtered = allWithMeta.filter((x) => (x.meta?.collectionId ?? null) === collectionIdFilter)
     totalFound = filtered.length
     const slice = filtered.slice((page - 1) * perPage, page * perPage)
-    items = slice.map(({ id, owner, meta }) => buildItem(id, owner, meta))
+    items = dedupeExploreItems(slice.map(({ id, owner, meta }) => buildItem(id, owner, meta)))
   } else {
     // Normal path: paginate first, then fetch metadata for this page only.
     totalFound = found.length
@@ -139,10 +164,11 @@ export async function GET(request: NextRequest) {
       const meta = await buildPhaseTokenMetadataJson(contractId, id)
       return buildItem(id, owner, meta)
     })
+    items = dedupeExploreItems(items)
   }
 
   return NextResponse.json(
-    { items, total: totalFound, page, perPage },
+    { items, total: totalFound, page, perPage, content_hash_dedup_enabled: isFeatureEnabled("phase-127") },
     {
       headers: {
         ...CORS,

--- a/app/api/market/[id]/offers/route.ts
+++ b/app/api/market/[id]/offers/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server"
 import { StrKey } from "@stellar/stellar-sdk"
-import { getListing, getOffers, createOffer } from "@/lib/market-store"
+import { createOffer, getListing, getOffers, isPhase100Enabled, recordCreatorProfileView } from "@/lib/market-store"
 import { createNotification } from "@/lib/notification-store"
 import { createApiRequestContext } from "@/lib/api-observability"
 
@@ -15,8 +15,21 @@ export async function GET(
   const { id } = await params
 
   try {
+    const creatorWallet = request.nextUrl.searchParams.get("creator_wallet")?.trim() ?? ""
+    const viewerWallet = request.nextUrl.searchParams.get("viewer_wallet")?.trim() ?? ""
+    if (isPhase100Enabled() && creatorWallet && StrKey.isValidEd25519PublicKey(creatorWallet)) {
+      await recordCreatorProfileView({
+        creator_wallet: creatorWallet,
+        viewer_wallet: viewerWallet && StrKey.isValidEd25519PublicKey(viewerWallet) ? viewerWallet : undefined,
+        source: "market",
+      }).catch((error) => api.log("warn", "market.profile_view.record_failed", { error }))
+    }
+
     const offers = await getOffers(id)
-    return api.json({ offers }, { event: "market.offers.loaded", metadata: { listing_id: id } })
+    return api.json(
+      { offers, profile_view_analytics_enabled: isPhase100Enabled() },
+      { event: "market.offers.loaded", metadata: { listing_id: id } },
+    )
   } catch (error) {
     return api.errorJson(error, 500, "market.offers.load_failed")
   }

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -4,10 +4,13 @@ import {
   getNotifications,
   getNotificationPreferences,
   getUnreadCount,
+  isPhase128Enabled,
   isNotificationPreferencesEnabled,
   markAllRead,
   markRead,
+  rotateIpfsGatewayAuth,
   saveNotificationPreferences,
+  type GatewayAuthRotation,
   type NotificationPreferences,
 } from "@/lib/notification-store"
 
@@ -29,6 +32,7 @@ export async function GET(request: NextRequest) {
     unread_count,
     preferences,
     preferences_feature_enabled: isNotificationPreferencesEnabled(),
+    gateway_auth_rotation_feature_enabled: isPhase128Enabled(),
   })
 }
 
@@ -37,6 +41,15 @@ type NotifActionBody = {
   action?: unknown
   id?: unknown
   preferences?: unknown
+  gateway_auth?: unknown
+}
+
+function redactGatewayAuthRotation(rotation: GatewayAuthRotation): GatewayAuthRotation {
+  return {
+    ...rotation,
+    active_token_hash: `${rotation.active_token_hash.slice(0, 12)}...`,
+    previous_token_hash: rotation.previous_token_hash ? `${rotation.previous_token_hash.slice(0, 12)}...` : null,
+  }
 }
 
 function parsePreferencePatch(input: unknown): Partial<Omit<NotificationPreferences, "updated_at">> | null {
@@ -95,6 +108,24 @@ export async function POST(request: NextRequest) {
       preferences,
       preferences_feature_enabled: isNotificationPreferencesEnabled(),
     })
+  }
+
+  if (body.action === "rotate_gateway_auth") {
+    try {
+      const rotation = await rotateIpfsGatewayAuth(body.gateway_auth)
+      return NextResponse.json({
+        ok: true,
+        rotation: redactGatewayAuthRotation(rotation),
+        gateway_auth_rotation_feature_enabled: isPhase128Enabled(),
+      })
+    } catch (error) {
+      const code = error instanceof Error && "code" in error ? String((error as { code: unknown }).code) : "UNKNOWN"
+      const details = error instanceof Error && "details" in error ? (error as { details?: unknown }).details : undefined
+      return NextResponse.json(
+        { error: error instanceof Error ? error.message : "gateway auth rotation failed", code, details },
+        { status: code === "FLAG_DISABLED" ? 404 : 400 },
+      )
+    }
   }
 
   return NextResponse.json({ error: "unknown action" }, { status: 400 })

--- a/app/api/profile/follow/route.ts
+++ b/app/api/profile/follow/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from "next/server"
 import { StrKey } from "@stellar/stellar-sdk"
-import { followUser, unfollowUser, getFollowCounts, isFollowing } from "@/lib/follow-store"
+import {
+  followUser,
+  unfollowUser,
+  getFollowCounts,
+  isFollowing,
+  isPhase118Enabled,
+  validateSep50MetadataBeforePin,
+} from "@/lib/follow-store"
 import { createNotification } from "@/lib/notification-store"
 import { getProfile } from "@/lib/profile-store"
 import { checkAndUnlock } from "@/lib/achievement-store"
@@ -25,6 +32,7 @@ type FollowBody = {
   from?: unknown
   to?: unknown
   action?: unknown
+  metadata?: unknown
 }
 
 export async function POST(request: NextRequest) {
@@ -47,6 +55,15 @@ export async function POST(request: NextRequest) {
   if (body.action !== "follow" && body.action !== "unfollow") {
     return NextResponse.json({ error: "action must be follow or unfollow" }, { status: 400 })
   }
+  if (isPhase118Enabled() && body.metadata !== undefined) {
+    const validation = validateSep50MetadataBeforePin(body.metadata)
+    if (!validation.ok) {
+      return NextResponse.json(
+        { error: validation.error.message, code: validation.error.code, details: validation.error.details },
+        { status: 400 },
+      )
+    }
+  }
 
   if (body.action === "follow") {
     await followUser(body.from, body.to)
@@ -67,5 +84,5 @@ export async function POST(request: NextRequest) {
   }
 
   const counts = await getFollowCounts(body.to)
-  return NextResponse.json({ ok: true, ...counts })
+  return NextResponse.json({ ok: true, ...counts, metadata_validation_enabled: isPhase118Enabled() })
 }

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -14,6 +14,7 @@ type ExploreResponse = {
   total: number
   page: number
   perPage: number
+  content_hash_dedup_enabled?: boolean
 }
 
 const navLink =
@@ -293,6 +294,12 @@ function ArtifactCard({
         {item.worldName && (
           <span className="inline-block w-fit border border-cyan-400/40 bg-cyan-950/50 px-1.5 py-0.5 text-[8px] uppercase tracking-widest text-cyan-400">
             ◈ {item.worldName}
+          </span>
+        )}
+
+        {item.duplicateOfTokenId && (
+          <span className="inline-block w-fit border border-amber-400/40 bg-amber-950/30 px-1.5 py-0.5 text-[8px] uppercase tracking-widest text-amber-300">
+            {isEs ? `Duplicado de #${item.duplicateOfTokenId}` : `Duplicate of #${item.duplicateOfTokenId}`}
           </span>
         )}
 

--- a/app/profile/[wallet]/follow-button.tsx
+++ b/app/profile/[wallet]/follow-button.tsx
@@ -11,6 +11,7 @@ export function FollowButton({ targetWallet }: Props) {
   const { address } = useWallet()
   const [following, setFollowing] = useState<boolean | null>(null)
   const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!address || address === targetWallet) return
@@ -25,6 +26,7 @@ export function FollowButton({ targetWallet }: Props) {
   async function toggle() {
     if (!address || busy) return
     setBusy(true)
+    setError(null)
     const action = following ? "unfollow" : "follow"
     try {
       const res = await fetch("/api/profile/follow", {
@@ -32,28 +34,40 @@ export function FollowButton({ targetWallet }: Props) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ from: address, to: targetWallet, action }),
       })
-      if (res.ok) setFollowing(!following)
+      if (res.ok) {
+        setFollowing(!following)
+      } else {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null
+        setError(data?.error ?? "Follow request failed")
+      }
     } finally {
       setBusy(false)
     }
   }
 
   return (
-    <button
-      type="button"
-      disabled={busy || following === null}
-      onClick={() => void toggle()}
-      className={`shrink-0 font-mono text-[10px] uppercase tracking-widest px-4 py-1.5 border transition-colors disabled:opacity-40 ${
-        following
-          ? "border-violet-700/40 text-violet-500 hover:border-red-500/40 hover:text-red-400"
-          : "border-[#534AB7] bg-[#534AB7]/10 text-[#7F77DD] hover:bg-[#534AB7]/20"
-      }`}
-    >
-      {following === null
-        ? "···"
-        : following
-        ? "[ FOLLOWING ]"
-        : "[ FOLLOW ]"}
-    </button>
+    <span className="inline-flex flex-col items-end gap-1">
+      <button
+        type="button"
+        disabled={busy || following === null}
+        onClick={() => void toggle()}
+        className={`shrink-0 font-mono text-[10px] uppercase tracking-widest px-4 py-1.5 border transition-colors disabled:opacity-40 ${
+          following
+            ? "border-violet-700/40 text-violet-500 hover:border-red-500/40 hover:text-red-400"
+            : "border-[#534AB7] bg-[#534AB7]/10 text-[#7F77DD] hover:bg-[#534AB7]/20"
+        }`}
+      >
+        {following === null
+          ? "···"
+          : following
+          ? "[ FOLLOWING ]"
+          : "[ FOLLOW ]"}
+      </button>
+      {error && (
+        <span className="max-w-48 text-right font-mono text-[9px] uppercase tracking-wider text-red-400">
+          {error}
+        </span>
+      )}
+    </span>
   )
 }

--- a/components/crt-collection-preview.tsx
+++ b/components/crt-collection-preview.tsx
@@ -16,6 +16,8 @@ type Props = {
   attributes: Attribute[]
   collectionId: number | null
   owner: string | null
+  contentHash?: string
+  duplicateOfTokenId?: number
 }
 
 const SCANLINES = {
@@ -56,6 +58,8 @@ export function CrtCollectionPreview({
   attributes,
   collectionId,
   owner,
+  contentHash,
+  duplicateOfTokenId,
 }: Props) {
   const collectionName = parseCollectionName(name)
   const creatorDisplay = owner ? truncateAddress(owner) : "UNKNOWN"
@@ -145,6 +149,12 @@ export function CrtCollectionPreview({
           <MetaRow label="CREATOR" value={creatorDisplay} />
           {collectionId != null && (
             <MetaRow label="COLLECTION_ID" value={String(collectionId)} />
+          )}
+          {contentHash && (
+            <MetaRow label="CONTENT_HASH" value={contentHash.slice(0, 16)} />
+          )}
+          {duplicateOfTokenId && (
+            <MetaRow label="DUPLICATE_OF" value={`#${duplicateOfTokenId}`} />
           )}
           {displayAttrs.map((attr) => (
             <MetaRow

--- a/components/notifications-modal.tsx
+++ b/components/notifications-modal.tsx
@@ -224,6 +224,7 @@ export function NotificationsModal() {
         notifications: Notification[]
         unread_count: number
         preferences?: NotificationPreferences
+        gateway_auth_rotation_feature_enabled?: boolean
       }
       setNotifications(data.notifications)
       setUnreadCount(data.unread_count)

--- a/lib/__tests__/explore-dedup.test.ts
+++ b/lib/__tests__/explore-dedup.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, beforeEach } from "node:test"
+import * as assert from "node:assert/strict"
+import { assetContentHash, dedupeExploreItems, type ExploreItem } from "@/app/api/explore/route"
+
+const baseItem: ExploreItem = {
+  tokenId: 1,
+  name: "One",
+  image: "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+  collectionId: null,
+  ownerTruncated: "GAAAAA...AAAA",
+}
+
+describe("phase-127 content-hash deduplication", () => {
+  beforeEach(() => {
+    process.env.FEATURE_PHASE_127 = "1"
+  })
+
+  it("marks repeated assets with the first token id", () => {
+    const items = dedupeExploreItems([
+      baseItem,
+      { ...baseItem, tokenId: 2, name: "Two", image: baseItem.image.toUpperCase() },
+      { ...baseItem, tokenId: 3, name: "Three", image: "ipfs://bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku" },
+    ])
+
+    assert.equal(items[0]?.duplicateOfTokenId, undefined)
+    assert.equal(items[1]?.duplicateOfTokenId, 1)
+    assert.equal(items[2]?.duplicateOfTokenId, undefined)
+    assert.equal(items[0]?.contentHash, items[1]?.contentHash)
+  })
+
+  it("does not hash empty image values", () => {
+    assert.equal(assetContentHash({ image: " " }), null)
+  })
+})

--- a/lib/__tests__/follow-sep50.test.ts
+++ b/lib/__tests__/follow-sep50.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from "node:test"
+import * as assert from "node:assert/strict"
+import { validateSep50MetadataBeforePin } from "@/lib/follow-store"
+
+describe("phase-118 SEP-50 metadata validation", () => {
+  const validMetadata = {
+    name: "Phase Artifact #1",
+    description: "Forged on Soroban",
+    image: "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    external_url: "https://phase.example/chamber",
+    attributes: [
+      { trait_type: "token_id", value: 1, display_type: "number" },
+      { trait_type: "network", value: "stellar-testnet" },
+    ],
+    collectionId: 1,
+  }
+
+  it("accepts SEP-50-compatible metadata before pinning", () => {
+    const result = validateSep50MetadataBeforePin(validMetadata, { force: true })
+    assert.equal(result.ok, true)
+    if (result.ok) {
+      assert.equal(result.metadata.name, validMetadata.name)
+      assert.equal(result.metadata.attributes.length, 2)
+    }
+  })
+
+  it("rejects invalid metadata with structured details", () => {
+    const result = validateSep50MetadataBeforePin(
+      { ...validMetadata, image: "http://insecure.example/art.png", extra: true },
+      { force: true },
+    )
+    assert.equal(result.ok, false)
+    if (!result.ok) {
+      assert.equal(result.error.code, "SEP50_METADATA_INVALID")
+      assert.ok(result.error.details)
+    }
+  })
+
+  it("is feature-flag gated by default", () => {
+    delete process.env.FEATURE_PHASE_118
+    delete process.env.NEXT_PUBLIC_FEATURE_PHASE_118
+    const result = validateSep50MetadataBeforePin(validMetadata)
+    assert.equal(result.ok, false)
+    if (!result.ok) assert.equal(result.error.code, "FLAG_DISABLED")
+  })
+})

--- a/lib/__tests__/market-profile-views.test.ts
+++ b/lib/__tests__/market-profile-views.test.ts
@@ -1,0 +1,36 @@
+import { mkdtemp } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { describe, it, beforeEach } from "node:test"
+import * as assert from "node:assert/strict"
+import { Keypair } from "@stellar/stellar-sdk"
+import { getCreatorProfileViewAnalytics, recordCreatorProfileView } from "@/lib/market-store"
+
+describe("phase-100 creator profile view analytics", () => {
+  beforeEach(async () => {
+    process.env.PHASE_SERVER_DATA_DIR = await mkdtemp(path.join(os.tmpdir(), "phase-profile-views-"))
+  })
+
+  it("aggregates total and unique profile views", async () => {
+    const creator = Keypair.random().publicKey()
+    const viewer = Keypair.random().publicKey()
+    await recordCreatorProfileView({ creator_wallet: creator, viewer_wallet: viewer, source: "profile" }, { force: true, now: 1_000 })
+    const analytics = await recordCreatorProfileView({ creator_wallet: creator, viewer_wallet: viewer, source: "market" }, { force: true, now: 2_000 })
+
+    assert.equal(analytics.total_views, 2)
+    assert.equal(analytics.unique_viewers, 1)
+    assert.equal(analytics.last_viewed_at, 2_000)
+    assert.equal(analytics.sources.profile, 1)
+    assert.equal(analytics.sources.market, 1)
+    assert.match(analytics.viewer_hashes[0] ?? "", /^[a-f0-9]{64}$/)
+    assert.notEqual(analytics.viewer_hashes[0], viewer)
+  })
+
+  it("reads analytics by creator wallet", async () => {
+    const creator = Keypair.random().publicKey()
+    await recordCreatorProfileView({ creator_wallet: creator, source: "dashboard" }, { force: true, now: 3_000 })
+    const analytics = await getCreatorProfileViewAnalytics(creator)
+    assert.equal(analytics?.total_views, 1)
+    assert.equal(analytics?.sources.dashboard, 1)
+  })
+})

--- a/lib/__tests__/notification-gateway-auth.test.ts
+++ b/lib/__tests__/notification-gateway-auth.test.ts
@@ -1,0 +1,48 @@
+import { mkdtemp } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { describe, it, beforeEach } from "node:test"
+import * as assert from "node:assert/strict"
+import { rotateIpfsGatewayAuth } from "@/lib/notification-store"
+
+describe("phase-128 IPFS gateway auth rotation", () => {
+  beforeEach(async () => {
+    process.env.PHASE_SERVER_DATA_DIR = await mkdtemp(path.join(os.tmpdir(), "phase-gateway-auth-"))
+  })
+
+  it("rotates active token while preserving a temporary previous token hash", async () => {
+    const first = await rotateIpfsGatewayAuth(
+      {
+        gateway: "pinata",
+        private_tier: "pro",
+        next_token: "token-one-with-safe-length",
+        rotated_by: "security",
+        overlap_ms: 1000,
+      },
+      { force: true, now: 1_000 },
+    )
+    const second = await rotateIpfsGatewayAuth(
+      {
+        gateway: "pinata",
+        private_tier: "pro",
+        next_token: "token-two-with-safe-length",
+        rotated_by: "security",
+        overlap_ms: 1000,
+      },
+      { force: true, now: 2_000 },
+    )
+
+    assert.match(first.active_token_hash, /^[a-f0-9]{64}$/)
+    assert.match(second.active_token_hash, /^[a-f0-9]{64}$/)
+    assert.notEqual(first.active_token_hash, second.active_token_hash)
+    assert.equal(second.previous_token_hash, first.active_token_hash)
+    assert.equal(second.previous_expires_at, 3_000)
+  })
+
+  it("rejects malformed rotation payloads", async () => {
+    await assert.rejects(
+      () => rotateIpfsGatewayAuth({ gateway: "pinata", private_tier: "pro", next_token: "short", rotated_by: "" }, { force: true }),
+      /valid gateway rotation payload required/,
+    )
+  })
+})

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -13,35 +13,63 @@
  * - phase-122: off-chain metadata delta storage
  * - phase-123: IPFS timeout fallback chain
  * - phase-124: metadata version migration tool
+ * - phase-100: creator profile view analytics
+ * - phase-118: SEP-50 metadata validation before pin
+ * - phase-127: content-hash deduplication for repeated assets
+ * - phase-128: IPFS gateway auth rotation for private pinning tiers
  */
 
 export type PhaseFeatureFlag =
+  | "phase-100"
+  | "phase-104"
+  | "phase-105"
+  | "phase-106"
   | "phase-107"
+  | "phase-108"
+  | "phase-109"
+  | "phase-110"
   | "phase-111"
+  | "phase-112"
   | "phase-113"
   | "phase-114"
+  | "phase-115"
   | "phase-116"
   | "phase-117"
+  | "phase-118"
   | "phase-119"
   | "phase-120"
   | "phase-121"
   | "phase-122"
   | "phase-123"
   | "phase-124"
+  | "phase-127"
+  | "phase-128"
 
 const FLAG_ENV_MAP: Record<PhaseFeatureFlag, string[]> = {
+  "phase-100": ["NEXT_PUBLIC_FEATURE_PHASE_100", "FEATURE_PHASE_100"],
+  "phase-104": ["NEXT_PUBLIC_FEATURE_PHASE_104", "FEATURE_PHASE_104"],
+  "phase-105": ["NEXT_PUBLIC_FEATURE_PHASE_105", "FEATURE_PHASE_105"],
+  "phase-106": ["NEXT_PUBLIC_FEATURE_PHASE_106", "FEATURE_PHASE_106"],
   "phase-107": ["NEXT_PUBLIC_FEATURE_PHASE_107", "FEATURE_PHASE_107"],
+  "phase-108": ["NEXT_PUBLIC_FEATURE_PHASE_108", "FEATURE_PHASE_108"],
+  "phase-109": ["NEXT_PUBLIC_FEATURE_PHASE_109", "FEATURE_PHASE_109"],
+  "phase-110": ["NEXT_PUBLIC_FEATURE_PHASE_110", "FEATURE_PHASE_110"],
   "phase-111": ["NEXT_PUBLIC_FEATURE_PHASE_111", "FEATURE_PHASE_111"],
+  "phase-112": ["NEXT_PUBLIC_FEATURE_PHASE_112", "FEATURE_PHASE_112"],
   "phase-113": ["NEXT_PUBLIC_FEATURE_PHASE_113", "FEATURE_PHASE_113"],
   "phase-114": ["NEXT_PUBLIC_FEATURE_PHASE_114", "FEATURE_PHASE_114"],
+  "phase-115": ["NEXT_PUBLIC_FEATURE_PHASE_115", "FEATURE_PHASE_115"],
   "phase-116": ["NEXT_PUBLIC_FEATURE_PHASE_116", "FEATURE_PHASE_116"],
   "phase-117": ["NEXT_PUBLIC_FEATURE_PHASE_117", "FEATURE_PHASE_117"],
+  "phase-118": ["NEXT_PUBLIC_FEATURE_PHASE_118", "FEATURE_PHASE_118"],
   "phase-119": ["NEXT_PUBLIC_FEATURE_PHASE_119", "FEATURE_PHASE_119"],
   "phase-120": ["NEXT_PUBLIC_FEATURE_PHASE_120", "FEATURE_PHASE_120"],
   "phase-121": ["NEXT_PUBLIC_FEATURE_PHASE_121", "FEATURE_PHASE_121"],
   "phase-122": ["NEXT_PUBLIC_FEATURE_PHASE_122", "FEATURE_PHASE_122"],
   "phase-123": ["NEXT_PUBLIC_FEATURE_PHASE_123", "FEATURE_PHASE_123"],
   "phase-124": ["NEXT_PUBLIC_FEATURE_PHASE_124", "FEATURE_PHASE_124"],
+  "phase-127": ["NEXT_PUBLIC_FEATURE_PHASE_127", "FEATURE_PHASE_127"],
+  "phase-128": ["NEXT_PUBLIC_FEATURE_PHASE_128", "FEATURE_PHASE_128"],
 }
 
 function isTruthy(v: string | undefined): boolean {
@@ -64,7 +92,7 @@ export function featureFlagEnvKeys(flag: PhaseFeatureFlag): string[] {
 }
 
 export function getEnabledFeatureFlags(): PhaseFeatureFlag[] {
-  const all: PhaseFeatureFlag[] = ["phase-107", "phase-111", "phase-113", "phase-114", "phase-116", "phase-117", "phase-119", "phase-120", "phase-121", "phase-122", "phase-123", "phase-124"]
+  const all: PhaseFeatureFlag[] = ["phase-100", "phase-104", "phase-105", "phase-106", "phase-107", "phase-108", "phase-109", "phase-110", "phase-111", "phase-112", "phase-113", "phase-114", "phase-115", "phase-116", "phase-117", "phase-118", "phase-119", "phase-120", "phase-121", "phase-122", "phase-123", "phase-124", "phase-127", "phase-128"]
   return all.filter(isFeatureEnabled)
 }
 

--- a/lib/follow-store.ts
+++ b/lib/follow-store.ts
@@ -1,5 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { z } from "zod"
+import { isFeatureEnabled, flagRollbackNote } from "@/lib/feature-flags"
 import { serverDataJsonPath } from "@/lib/server-data-paths"
 
 type FollowEntry = {
@@ -8,6 +10,81 @@ type FollowEntry = {
 }
 
 type FollowStore = Record<string, FollowEntry>
+
+const UriSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(2048)
+  .refine((value) => /^https:\/\//i.test(value) || /^ipfs:\/\/[A-Za-z0-9._/-]+$/i.test(value), {
+    message: "URI must be https:// or ipfs://",
+  })
+
+export const Sep50MetadataAttributeSchema = z.object({
+  trait_type: z.string().trim().min(1).max(64),
+  value: z.union([z.string().trim().min(1).max(256), z.number().finite()]),
+  display_type: z.enum(["number"]).optional(),
+})
+
+export const Sep50MetadataSchema = z
+  .object({
+    name: z.string().trim().min(1).max(128),
+    description: z.string().trim().min(1).max(1000),
+    image: UriSchema,
+    external_url: UriSchema.optional(),
+    attributes: z.array(Sep50MetadataAttributeSchema).max(64).default([]),
+    collectionId: z.number().int().positive().nullable().optional(),
+  })
+  .strict()
+
+export type Sep50Metadata = z.infer<typeof Sep50MetadataSchema>
+
+export class FollowStoreValidationError extends Error {
+  code: "FLAG_DISABLED" | "SEP50_METADATA_INVALID"
+  details?: unknown
+
+  constructor(code: FollowStoreValidationError["code"], message: string, details?: unknown) {
+    super(message)
+    this.name = "FollowStoreValidationError"
+    this.code = code
+    this.details = details
+  }
+}
+
+export function isPhase118Enabled(): boolean {
+  return isFeatureEnabled("phase-118")
+}
+
+export function phase118RollbackNote(): string {
+  return flagRollbackNote("phase-118")
+}
+
+export function validateSep50MetadataBeforePin(input: unknown, opts: { force?: boolean } = {}):
+  | { ok: true; metadata: Sep50Metadata }
+  | { ok: false; error: FollowStoreValidationError } {
+  if (!opts.force && !isPhase118Enabled()) {
+    return {
+      ok: false,
+      error: new FollowStoreValidationError("FLAG_DISABLED", "phase-118 flag disabled", {
+        rollback: phase118RollbackNote(),
+      }),
+    }
+  }
+
+  const parsed = Sep50MetadataSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: new FollowStoreValidationError(
+        "SEP50_METADATA_INVALID",
+        "Metadata does not satisfy SEP-50-compatible JSON requirements",
+        parsed.error.flatten(),
+      ),
+    }
+  }
+
+  return { ok: true, metadata: parsed.data }
+}
 
 async function readStore(): Promise<FollowStore> {
   try {

--- a/lib/market-store.ts
+++ b/lib/market-store.ts
@@ -1,6 +1,9 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import path from "node:path"
-import { randomUUID } from "node:crypto"
+import { createHash, randomUUID } from "node:crypto"
+import { StrKey } from "@stellar/stellar-sdk"
+import { z } from "zod"
+import { isFeatureEnabled, flagRollbackNote } from "@/lib/feature-flags"
 import { serverDataJsonPath } from "@/lib/server-data-paths"
 
 export type ListingStatus = "active" | "sold" | "cancelled"
@@ -33,8 +36,46 @@ export type Offer = {
 
 type ListingsStore = Record<string, Listing>
 type OffersStore = Record<string, Offer>
+type ProfileViewAnalyticsStore = Record<string, CreatorProfileViewAnalytics>
 
 const OFFER_TTL_MS = 48 * 60 * 60 * 1000 // 48h
+
+export const ProfileViewEventSchema = z.object({
+  creator_wallet: z.string().trim().refine((value) => StrKey.isValidEd25519PublicKey(value), "valid creator wallet required"),
+  viewer_wallet: z.string().trim().refine((value) => StrKey.isValidEd25519PublicKey(value), "valid viewer wallet required").optional(),
+  source: z.enum(["profile", "market", "dashboard"]).default("profile"),
+})
+
+export type ProfileViewEvent = z.infer<typeof ProfileViewEventSchema>
+
+export type CreatorProfileViewAnalytics = {
+  creator_wallet: string
+  total_views: number
+  unique_viewers: number
+  last_viewed_at: number
+  sources: Partial<Record<ProfileViewEvent["source"], number>>
+  viewer_hashes: string[]
+}
+
+export class MarketStoreValidationError extends Error {
+  code: "FLAG_DISABLED" | "VALIDATION_FAILED"
+  details?: unknown
+
+  constructor(code: MarketStoreValidationError["code"], message: string, details?: unknown) {
+    super(message)
+    this.name = "MarketStoreValidationError"
+    this.code = code
+    this.details = details
+  }
+}
+
+export function isPhase100Enabled(): boolean {
+  return isFeatureEnabled("phase-100")
+}
+
+export function phase100RollbackNote(): string {
+  return flagRollbackNote("phase-100")
+}
 
 async function readJson<T extends object>(filePath: string): Promise<T> {
   try { return JSON.parse(await readFile(filePath, "utf8")) as T }
@@ -44,6 +85,62 @@ async function readJson<T extends object>(filePath: string): Promise<T> {
 async function writeJson<T extends object>(filePath: string, data: T): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true })
   await writeFile(filePath, JSON.stringify(data, null, 2), "utf8")
+}
+
+function viewerAnalyticsKey(viewerWallet?: string): string | null {
+  if (!viewerWallet) return null
+  return createHash("sha256").update(viewerWallet.toUpperCase(), "utf8").digest("hex")
+}
+
+export async function recordCreatorProfileView(input: unknown, opts: { force?: boolean; now?: number } = {}): Promise<CreatorProfileViewAnalytics> {
+  if (!opts.force && !isPhase100Enabled()) {
+    throw new MarketStoreValidationError("FLAG_DISABLED", "phase-100 flag disabled", {
+      rollback: phase100RollbackNote(),
+    })
+  }
+
+  const parsed = ProfileViewEventSchema.safeParse(input)
+  if (!parsed.success) {
+    throw new MarketStoreValidationError("VALIDATION_FAILED", "valid profile view payload required", parsed.error.flatten())
+  }
+
+  const event = parsed.data
+  const now = opts.now ?? Date.now()
+  const store = await readJson<ProfileViewAnalyticsStore>(serverDataJsonPath("marketProfileViews"))
+  const current = store[event.creator_wallet] ?? {
+    creator_wallet: event.creator_wallet,
+    total_views: 0,
+    unique_viewers: 0,
+    last_viewed_at: 0,
+    sources: {},
+    viewer_hashes: [],
+  }
+
+  const viewerKey = viewerAnalyticsKey(event.viewer_wallet)
+  const viewerHashes = viewerKey && !current.viewer_hashes.includes(viewerKey)
+    ? [...current.viewer_hashes, viewerKey]
+    : current.viewer_hashes
+
+  const next: CreatorProfileViewAnalytics = {
+    ...current,
+    total_views: current.total_views + 1,
+    unique_viewers: viewerHashes.length,
+    last_viewed_at: now,
+    sources: {
+      ...current.sources,
+      [event.source]: (current.sources[event.source] ?? 0) + 1,
+    },
+    viewer_hashes: viewerHashes,
+  }
+
+  store[event.creator_wallet] = next
+  await writeJson(serverDataJsonPath("marketProfileViews"), store)
+  return next
+}
+
+export async function getCreatorProfileViewAnalytics(creatorWallet: string): Promise<CreatorProfileViewAnalytics | null> {
+  const store = await readJson<ProfileViewAnalyticsStore>(serverDataJsonPath("marketProfileViews"))
+  return store[creatorWallet] ?? null
 }
 
 // ── Listings ──────────────────────────────────────────────────────────────────

--- a/lib/notification-store.ts
+++ b/lib/notification-store.ts
@@ -1,6 +1,9 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { randomUUID } from "node:crypto"
+import { createHash } from "node:crypto"
+import { z } from "zod"
+import { isFeatureEnabled, flagRollbackNote } from "@/lib/feature-flags"
 import { serverDataJsonPath } from "@/lib/server-data-paths"
 
 export type NotificationType =
@@ -27,6 +30,7 @@ export type Notification = {
 }
 
 type NotificationStore = Record<string, Notification[]>
+type GatewayAuthRotationStore = Record<string, GatewayAuthRotation>
 
 const MAX_PER_WALLET = 50
 // phase-98: profile-level notification preferences.
@@ -48,6 +52,108 @@ export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
 export function isNotificationPreferencesEnabled(): boolean {
   const value = (process.env.NEXT_PUBLIC_FEATURE_PHASE_98 ?? process.env.FEATURE_PHASE_98 ?? "").trim().toLowerCase()
   return value === "1" || value === "true" || value === "yes" || value === "on"
+}
+
+export function isPhase128Enabled(): boolean {
+  return isFeatureEnabled("phase-128")
+}
+
+export function phase128RollbackNote(): string {
+  return flagRollbackNote("phase-128")
+}
+
+export const GatewayAuthRotationSchema = z.object({
+  gateway: z.string().trim().min(2).max(64).regex(/^[a-z0-9._-]+$/i),
+  private_tier: z.enum(["starter", "pro", "enterprise"]),
+  next_token: z.string().trim().min(16).max(4096),
+  rotated_by: z.string().trim().min(1).max(128),
+  overlap_ms: z.number().int().min(0).max(86_400_000).default(900_000),
+})
+
+export type GatewayAuthRotationInput = z.infer<typeof GatewayAuthRotationSchema>
+
+export type GatewayAuthRotation = {
+  gateway: string
+  private_tier: GatewayAuthRotationInput["private_tier"]
+  active_token_hash: string
+  previous_token_hash: string | null
+  previous_expires_at: number | null
+  rotated_by: string
+  rotated_at: number
+}
+
+export class GatewayAuthRotationError extends Error {
+  code: "FLAG_DISABLED" | "VALIDATION_FAILED"
+  details?: unknown
+
+  constructor(code: GatewayAuthRotationError["code"], message: string, details?: unknown) {
+    super(message)
+    this.name = "GatewayAuthRotationError"
+    this.code = code
+    this.details = details
+  }
+}
+
+function hashGatewayToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex")
+}
+
+function gatewayRotationKey(gateway: string, privateTier: string): string {
+  return `${gateway.toLowerCase()}:${privateTier}`
+}
+
+async function readGatewayAuthRotationStore(): Promise<GatewayAuthRotationStore> {
+  try {
+    const raw = await readFile(serverDataJsonPath("ipfsGatewayAuthRotations"), "utf8")
+    const parsed = JSON.parse(raw) as GatewayAuthRotationStore
+    return parsed && typeof parsed === "object" ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+async function writeGatewayAuthRotationStore(data: GatewayAuthRotationStore): Promise<void> {
+  const filePath = serverDataJsonPath("ipfsGatewayAuthRotations")
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, JSON.stringify(data, null, 2), "utf8")
+}
+
+export async function rotateIpfsGatewayAuth(input: unknown, opts: { force?: boolean; now?: number } = {}): Promise<GatewayAuthRotation> {
+  if (!opts.force && !isPhase128Enabled()) {
+    throw new GatewayAuthRotationError("FLAG_DISABLED", "phase-128 flag disabled", {
+      rollback: phase128RollbackNote(),
+    })
+  }
+
+  const parsed = GatewayAuthRotationSchema.safeParse(input)
+  if (!parsed.success) {
+    throw new GatewayAuthRotationError("VALIDATION_FAILED", "valid gateway rotation payload required", parsed.error.flatten())
+  }
+
+  const now = opts.now ?? Date.now()
+  const data = parsed.data
+  const store = await readGatewayAuthRotationStore()
+  const key = gatewayRotationKey(data.gateway, data.private_tier)
+  const current = store[key]
+  const activeTokenHash = hashGatewayToken(data.next_token)
+
+  const rotation: GatewayAuthRotation = {
+    gateway: data.gateway,
+    private_tier: data.private_tier,
+    active_token_hash: activeTokenHash,
+    previous_token_hash: current?.active_token_hash && current.active_token_hash !== activeTokenHash
+      ? current.active_token_hash
+      : current?.previous_token_hash ?? null,
+    previous_expires_at: current?.active_token_hash && current.active_token_hash !== activeTokenHash
+      ? now + data.overlap_ms
+      : current?.previous_expires_at ?? null,
+    rotated_by: data.rotated_by,
+    rotated_at: now,
+  }
+
+  store[key] = rotation
+  await writeGatewayAuthRotationStore(store)
+  return rotation
 }
 
 async function readPreferenceStore(): Promise<NotificationPreferenceStore> {

--- a/lib/server-data-paths.ts
+++ b/lib/server-data-paths.ts
@@ -14,12 +14,16 @@ const FILES = {
   signalReplies: "signal-replies.json",
   profileFollows: "profile-follows.json",
   notifications: "notifications.json",
+  notificationPreferences: "notification-preferences.json",
   marketListings: "market-listings.json",
   marketOffers: "market-offers.json",
+  marketProfileViews: "market-profile-views.json",
   achievements: "achievements.json",
+  loreVersions: "lore-versions.json",
   worldLoreLinks: "world-lore-links.json",
   worldRoles: "world-roles.json",
   worldReaderProgress: "world-reader-progress.json",
+  ipfsGatewayAuthRotations: "ipfs-gateway-auth-rotations.json",
 } as const
 
 export type ServerDataFile = keyof typeof FILES


### PR DESCRIPTION
## Summary

- Add phase-118 SEP-50-compatible metadata validation before optional follow metadata pin paths, with structured validation errors and UI error surfacing.
- Add phase-128 private IPFS gateway auth rotation with schema validation, hashed token storage, redacted API output, and overlap-window rollback support.
- Add phase-100 creator profile view analytics helpers with hashed unique-view tracking and optional market-route recording.
- Add phase-127 content-hash deduplication for repeated explore assets with duplicate markers in gallery/preview wiring.
- Register the new feature flags and sidecar data files used by the stores.

## Rollback

- phase-100: unset NEXT_PUBLIC_FEATURE_PHASE_100 / FEATURE_PHASE_100 or set to 0/false and restart.
- phase-118: unset NEXT_PUBLIC_FEATURE_PHASE_118 / FEATURE_PHASE_118 or set to 0/false and restart.
- phase-127: unset NEXT_PUBLIC_FEATURE_PHASE_127 / FEATURE_PHASE_127 or set to 0/false and restart.
- phase-128: unset NEXT_PUBLIC_FEATURE_PHASE_128 / FEATURE_PHASE_128 or set to 0/false and restart.
- The sidecar JSON files are additive and can remain in place when flags are disabled.

## Tests

- PASS: npx tsx --test lib/__tests__/follow-sep50.test.ts lib/__tests__/notification-gateway-auth.test.ts lib/__tests__/market-profile-views.test.ts lib/__tests__/explore-dedup.test.ts
- FAIL: npm run build currently fails on pre-existing missing exports in lib/narrative-world-store.ts and Google Fonts fetch failures in this environment.
- FAIL: npx tsc --noEmit --pretty false currently fails on pre-existing world/narrative export gaps, script dotenv/SorobanRpc issues, and older helper type errors.
- FAIL: npm run lint cannot start because eslint is not declared in package.json/devDependencies.
- FAIL: npm run security:audit reports existing high/critical advisories in locked transitive dependencies.

Closes #136
Closes #145
Closes #118
Closes #144
