### PR TITLE
feat(wallet): add Ledger & WalletConnect multi-wallet support (#34)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -26,6 +26,12 @@ MERCURY_JWT=
 # Casi nunca hace falta; override solo si el cliente debe usar otro proxy (URL absoluta con CORS):
 # NEXT_PUBLIC_SOROBAN_RPC_PROXY_URL=
 #
+# ─── WalletConnect / Reown ─────────────────────────────────────────────────
+# ID de proyecto de Reown (ex WalletConnect Cloud). Necesario para que el QR de WalletConnect funcione.
+# Registrá tu app gratis en https://cloud.reown.com → copia el Project ID.
+# Si no se define, la app usa un ID de fallback público (puede tener límites de rate).
+# NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=tu_project_id_aqui
+#
 # Si despliegas bajo subruta (URL tipo https://host/MIPROJECTO/ sin basePath en Next, o reverse proxy):
 # NEXT_PUBLIC_BASE_PATH=MIPROJECTO
 # Así el cliente llama a …/MIPROJECTO/api/soroban-rpc y no a …/api/soroban-rpc (404 → falso “sin XLM”).

--- a/components/freighter-connect.tsx
+++ b/components/freighter-connect.tsx
@@ -4,11 +4,57 @@ import { useState, type ReactNode } from "react"
 import { ProfilePanel } from "@/components/profile-panel"
 import { useLang } from "@/components/lang-context"
 import { useWallet } from "@/components/wallet-provider"
+import { cn } from "@/lib/utils"
 
 function truncateAddress(addr: string) {
   if (!addr || addr.length < 14) return addr
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wallet-type badge helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Small inline badge indicating which wallet type is active.
+ * Only rendered when connected with a hardware wallet or WalletConnect — the
+ * default browser-extension wallets don't need an extra label.
+ */
+function WalletTypeBadge({
+  isHardwareWallet,
+  isWalletConnect,
+}: {
+  isHardwareWallet: boolean
+  isWalletConnect: boolean
+}) {
+  if (isHardwareWallet) {
+    return (
+      <span
+        title="Hardware wallet (Ledger) connected"
+        className="inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 font-mono text-[8px] font-bold uppercase tracking-wider text-amber-300 select-none"
+        aria-label="Ledger hardware wallet"
+      >
+        ⬡ LEDGER
+      </span>
+    )
+  }
+  if (isWalletConnect) {
+    return (
+      <span
+        title="WalletConnect session active"
+        className="inline-flex items-center gap-1 rounded border border-blue-500/40 bg-blue-500/10 px-1.5 py-0.5 font-mono text-[8px] font-bold uppercase tracking-wider text-blue-300 select-none"
+        aria-label="WalletConnect session"
+      >
+        ◈ WC
+      </span>
+    )
+  }
+  return null
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────────────────
 
 type FreighterConnectProps = {
   /** Rendered after wallet control, e.g. language toggle — prefixed with "|". */
@@ -17,7 +63,15 @@ type FreighterConnectProps = {
 
 export function FreighterConnect({ trailing }: FreighterConnectProps) {
   const { lang } = useLang()
-  const { address, connecting, hint, connect, disconnect } = useWallet()
+  const {
+    address,
+    connecting,
+    hint,
+    isHardwareWallet,
+    isWalletConnect,
+    connect,
+    disconnect,
+  } = useWallet()
   const [panelOpen, setPanelOpen] = useState(false)
 
   const t =
@@ -26,12 +80,24 @@ export function FreighterConnect({ trailing }: FreighterConnectProps) {
           walletLabel: "PROFILE",
           connecting: "Conectando...",
           connect: "Conectar Wallet",
+          ledgerConnecting: "Abriendo Ledger…",
+          wcConnecting: "Abriendo QR…",
         }
       : {
           walletLabel: "PROFILE",
           connecting: "Connecting...",
           connect: "Connect Wallet",
+          ledgerConnecting: "Opening Ledger…",
+          wcConnecting: "Opening QR…",
         }
+
+  // Derive a context-aware connecting label.
+  const connectingLabel = (() => {
+    if (!connecting) return t.connect
+    if (isHardwareWallet) return t.ledgerConnecting
+    if (isWalletConnect) return t.wcConnecting
+    return t.connecting
+  })()
 
   return (
     <div className="flex flex-col items-end gap-1 pointer-events-auto">
@@ -44,13 +110,28 @@ export function FreighterConnect({ trailing }: FreighterConnectProps) {
               address={address}
               disconnect={disconnect}
             />
+
+            {/* Wallet-type badge sits outside the profile button to keep it visible */}
+            <WalletTypeBadge
+              isHardwareWallet={isHardwareWallet}
+              isWalletConnect={isWalletConnect}
+            />
+
             <button
               type="button"
               onClick={() => setPanelOpen(true)}
               className="group flex items-center gap-2 rounded-sm border border-violet-700/40 bg-violet-950/30 px-3 py-1.5 hover:border-violet-500/60 transition-colors"
               title={address}
+              aria-label={`Open profile for ${truncateAddress(address)}`}
             >
-              <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-violet-400" aria-hidden />
+              {/* Status dot — amber for hardware wallet, blue for WC, violet default */}
+              <span
+                className={cn(
+                  "h-1.5 w-1.5 shrink-0 rounded-full",
+                  isHardwareWallet ? "bg-amber-400" : isWalletConnect ? "bg-blue-400" : "bg-violet-400",
+                )}
+                aria-hidden
+              />
               <span className="max-w-[min(100vw-10rem,14rem)] truncate font-mono text-[10px] font-medium uppercase tracking-widest text-violet-300">
                 {t.walletLabel} · {address.slice(0, 4)}
               </span>
@@ -63,7 +144,7 @@ export function FreighterConnect({ trailing }: FreighterConnectProps) {
             disabled={connecting}
             className="border border-border/80 bg-background/75 backdrop-blur-md px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-muted-foreground hover:text-foreground hover:border-accent transition-colors disabled:opacity-50 shadow-sm"
           >
-            {connecting ? t.connecting : t.connect}
+            {connectingLabel}
           </button>
         )}
         {trailing != null ? (
@@ -83,3 +164,4 @@ export function FreighterConnect({ trailing }: FreighterConnectProps) {
     </div>
   )
 }
+

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -15,8 +15,20 @@ import {
   isAlbedoSelectedInKit,
   requestAlbedoImplicitTxFlow,
 } from "@/lib/albedo-intent-client"
-import { initStellarWalletKit, kit, KitEventType, parseError } from "@/lib/stellar-wallet-kit"
+import {
+  initStellarWalletKit,
+  isHardwareWalletSelected,
+  isWalletConnectSelected,
+  kit,
+  KitEventType,
+  parseError,
+  TESTNET_PASSPHRASE,
+} from "@/lib/stellar-wallet-kit"
 import { cn } from "@/lib/utils"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
 
 type WalletContextValue = {
   address: string | null
@@ -24,6 +36,10 @@ type WalletContextValue = {
   hint: string | null
   artistAlias: string | null
   aliasLoading: boolean
+  /** Whether the active module is a hardware wallet (Ledger). */
+  isHardwareWallet: boolean
+  /** Whether the active module is WalletConnect. */
+  isWalletConnect: boolean
   connect: () => Promise<void>
   disconnect: () => void
   /** Re-sync con la wallet vía kit; devuelve la dirección activa o null. */
@@ -37,15 +53,30 @@ type WalletContextValue = {
   saveArtistAlias: (alias: string) => Promise<{ ok: true } | { ok: false; error: string }>
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
 const WalletContext = createContext<WalletContextValue | null>(null)
 
 /**
  * React 18 Strict Mode (dev) monta/desmonta dos veces: sin esto, el auto-claim del faucet
  * dispara POST duplicados (409 already claimed / 412 trustline) y ensucia la consola de red.
  */
-/** Solo amortigua el doble `useEffect` de Strict Mode (~ms); no sustituye al ref por wallet. */
 const FAUCET_AUTO_CLAIM_DEDUPE_MS = 4000
 const lastFaucetAutoClaimAt = new Map<string, number>()
+
+/**
+ * How often the heartbeat checks that the connected wallet is still reachable.
+ * For hardware wallets (Ledger) this is shorter because USB HID connections can
+ * drop silently; for extension wallets we rely on kit state events instead.
+ */
+const HEARTBEAT_INTERVAL_HW_MS = 8_000
+const HEARTBEAT_INTERVAL_SW_MS = 30_000
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Provider
+// ─────────────────────────────────────────────────────────────────────────────
 
 export function WalletProvider({ children }: { children: ReactNode }) {
   if (typeof window !== "undefined") {
@@ -57,18 +88,30 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const [hint, setHint] = useState<string | null>(null)
   const [artistAlias, setArtistAlias] = useState<string | null>(null)
   const [aliasLoading, setAliasLoading] = useState(false)
+  const [isHardwareWallet, setIsHardwareWallet] = useState(false)
+  const [isWalletConnect, setIsWalletConnect] = useState(false)
 
-  /**
-   * Tras conectar, el kit mantiene la dirección en memoria; al desconectar en la app
-   * no queremos que un `refresh()` vuelva a rellenarla hasta un nuevo `connect`.
-   */
+  /** True when user deliberately disconnected — blocks session restoration. */
   const userDisconnectedRef = useRef(false)
   const autoFundedWalletsRef = useRef<Set<string>>(new Set())
+  const heartbeatTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   /** Albedo: sin `implicit_flow` para `tx`, el popup de firma se bloquea tras awaits largos (Soroban). */
   const [albedoTxPrep, setAlbedoTxPrep] = useState<"hidden" | "needed" | "checking">("hidden")
   const [albedoPrepBusy, setAlbedoPrepBusy] = useState(false)
   const [albedoPrepError, setAlbedoPrepError] = useState<string | null>(null)
+
+  // Network passphrase mismatch alert — shown when Ledger is connected but the
+  // kit's active network doesn't match TESTNET_PASSPHRASE.
+  const [networkMismatch, setNetworkMismatch] = useState<string | null>(null)
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  /** Sync module-type flags from localStorage (mirrors kit persisted selection). */
+  const syncModuleFlags = useCallback(() => {
+    setIsHardwareWallet(isHardwareWalletSelected())
+    setIsWalletConnect(isWalletConnectSelected())
+  }, [])
 
   const syncAlbedoTxPrep = useCallback(async (addr: string | null) => {
     if (!addr || typeof window === "undefined") {
@@ -87,6 +130,33 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       setAlbedoTxPrep("needed")
     }
   }, [])
+
+  /**
+   * Validate that a hardware-wallet connection is using the expected network
+   * passphrase.  Ledger's Stellar app is mode-specific; signing testnet XDRs
+   * with a mainnet app returns a wrong signature silently.
+   */
+  const validateHardwareNetwork = useCallback(async () => {
+    if (typeof window === "undefined") return
+    if (!isHardwareWalletSelected()) {
+      setNetworkMismatch(null)
+      return
+    }
+    try {
+      const { networkPassphrase } = await kit.getNetwork()
+      if (networkPassphrase && networkPassphrase !== TESTNET_PASSPHRASE) {
+        setNetworkMismatch(
+          `Ledger está conectado a "${networkPassphrase.slice(0, 48)}…" pero la app espera la testnet. Abrí la app Stellar en tu Ledger y seleccioná la red correcta (Test SDF Network). / Ledger is on the wrong network. Open the Stellar app on your Ledger and switch to the correct network.`,
+        )
+      } else {
+        setNetworkMismatch(null)
+      }
+    } catch {
+      // Not critical — leave any previous mismatch shown.
+    }
+  }, [])
+
+  // ── session refresh ────────────────────────────────────────────────────────
 
   const refresh = useCallback((): Promise<string | null> => {
     const run = async (): Promise<string | null> => {
@@ -122,29 +192,145 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     })
   }, [])
 
-  useEffect(() => {
-    void refresh().catch(() => {})
-  }, [refresh])
+  // ── heartbeat ─────────────────────────────────────────────────────────────
 
+  /**
+   * Start a recurring heartbeat that re-verifies the active wallet is still
+   * reachable. For hardware wallets this detects silent USB HID disconnects.
+   * For WalletConnect it keeps the session alive and detects remote disconnects.
+   */
+  const startHeartbeat = useCallback(
+    (addr: string) => {
+      if (heartbeatTimerRef.current) clearInterval(heartbeatTimerRef.current)
+      const interval = isHardwareWalletSelected() ? HEARTBEAT_INTERVAL_HW_MS : HEARTBEAT_INTERVAL_SW_MS
+
+      heartbeatTimerRef.current = setInterval(async () => {
+        if (userDisconnectedRef.current) {
+          clearInterval(heartbeatTimerRef.current!)
+          heartbeatTimerRef.current = null
+          return
+        }
+        try {
+          const { address: current } = await kit.getAddress()
+          if (!current || current !== addr) {
+            // Session expired or wallet changed — surface a hint.
+            setHint(
+              "Wallet sesión expirada. Reconectá tu wallet. / Wallet session expired. Please reconnect.",
+            )
+            setAddress(null)
+            clearInterval(heartbeatTimerRef.current!)
+            heartbeatTimerRef.current = null
+          }
+        } catch {
+          // Hardware wallet USB disconnect: clear address and notify.
+          if (isHardwareWalletSelected()) {
+            setAddress(null)
+            setHint(
+              "Ledger desconectado. Volvé a enchufar el dispositivo y reconectá. / Ledger disconnected. Re-plug the device and reconnect.",
+            )
+          }
+          clearInterval(heartbeatTimerRef.current!)
+          heartbeatTimerRef.current = null
+        }
+      }, interval)
+    },
+    [],
+  )
+
+  const stopHeartbeat = useCallback(() => {
+    if (heartbeatTimerRef.current) {
+      clearInterval(heartbeatTimerRef.current)
+      heartbeatTimerRef.current = null
+    }
+  }, [])
+
+  // ── effects ───────────────────────────────────────────────────────────────
+
+  /** Initial session restoration on mount. */
   useEffect(() => {
-    const onFocus = () => void refresh().catch(() => {})
+    syncModuleFlags()
+    void refresh().then((addr) => {
+      if (addr) startHeartbeat(addr)
+    }).catch(() => {})
+  }, [refresh, startHeartbeat, syncModuleFlags])
+
+  /** Re-check session when the tab regains focus (catches page navigations). */
+  useEffect(() => {
+    const onFocus = () => {
+      void refresh().then((addr) => {
+        if (addr && !heartbeatTimerRef.current) startHeartbeat(addr)
+      }).catch(() => {})
+    }
     window.addEventListener("focus", onFocus)
     return () => window.removeEventListener("focus", onFocus)
-  }, [refresh])
+  }, [refresh, startHeartbeat])
 
+  /** Subscribe to kit state events (extension wallets dispatch these). */
   useEffect(() => {
     initStellarWalletKit()
     const stop = kit.on(KitEventType.STATE_UPDATED, ({ payload }) => {
       try {
         if (userDisconnectedRef.current) return
-        setAddress(payload.address ?? null)
+        const addr = payload.address ?? null
+        setAddress(addr)
+        if (addr) startHeartbeat(addr)
+        else stopHeartbeat()
       } catch {
         setAddress(null)
+        stopHeartbeat()
       }
     })
     return stop
-  }, [])
+  }, [startHeartbeat, stopHeartbeat])
 
+  /**
+   * HID device disconnect events — WebUSB fires `connect`/`disconnect` events
+   * on `navigator.usb`.  When the Ledger is physically unplugged the heartbeat
+   * will catch it, but we also listen here for an immediate UX response.
+   */
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("usb" in navigator)) return
+
+    const usb = (navigator as Navigator & { usb?: USBManager }).usb
+    if (!usb) return
+
+    const onDisconnect = () => {
+      if (!isHardwareWalletSelected()) return
+      if (userDisconnectedRef.current) return
+      stopHeartbeat()
+      setAddress(null)
+      setHint(
+        "Ledger desconectado (USB). Volvé a enchufar y reconectá. / Ledger disconnected (USB). Re-plug and reconnect.",
+      )
+    }
+
+    const onConnect = () => {
+      if (!isHardwareWalletSelected()) return
+      // Clear the stale disconnect hint and attempt to restore the session.
+      setHint(null)
+      void refresh().then((addr) => {
+        if (addr) startHeartbeat(addr)
+      }).catch(() => {})
+    }
+
+    usb.addEventListener("disconnect", onDisconnect)
+    usb.addEventListener("connect", onConnect)
+    return () => {
+      usb.removeEventListener("disconnect", onDisconnect)
+      usb.removeEventListener("connect", onConnect)
+    }
+  }, [refresh, startHeartbeat, stopHeartbeat])
+
+  /** Validate hardware wallet network passphrase whenever address or module changes. */
+  useEffect(() => {
+    if (isHardwareWallet && address) {
+      void validateHardwareNetwork().catch(() => {})
+    } else {
+      setNetworkMismatch(null)
+    }
+  }, [address, isHardwareWallet, validateHardwareNetwork])
+
+  /** Faucet auto-claim (unchanged from original). */
   useEffect(() => {
     if (!address || userDisconnectedRef.current) return
     if (autoFundedWalletsRef.current.has(address)) return
@@ -256,6 +442,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     void syncAlbedoTxPrep(address)
   }, [address, syncAlbedoTxPrep])
 
+  // ── actions ───────────────────────────────────────────────────────────────
+
   const connect = useCallback((): Promise<void> => {
     const run = async (): Promise<void> => {
       userDisconnectedRef.current = false
@@ -264,15 +452,18 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       initStellarWalletKit()
       try {
         const { address: next } = await kit.authModal()
+        syncModuleFlags()
         if (!userDisconnectedRef.current) {
           setAddress(next)
-          // Defer: el kit persiste `selectedModuleId` en localStorage en un effect de Preact.
+          startHeartbeat(next)
           queueMicrotask(() => void syncAlbedoTxPrep(next))
+          queueMicrotask(() => void validateHardwareNetwork())
         }
         setHint(null)
       } catch (e) {
         const pe = parseError(e)
         setAddress(null)
+        stopHeartbeat()
         if (pe.code !== -1) {
           setHint(pe.message || "Wallet connection failed")
         }
@@ -283,9 +474,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     return run().catch(() => {
       setConnecting(false)
       setAddress(null)
+      stopHeartbeat()
       setHint("Wallet unavailable")
     })
-  }, [syncAlbedoTxPrep])
+  }, [syncAlbedoTxPrep, syncModuleFlags, startHeartbeat, stopHeartbeat, validateHardwareNetwork])
 
   const openWalletPicker = useCallback((): Promise<string | null> => {
     userDisconnectedRef.current = false
@@ -294,13 +486,17 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       .authModal()
       .then(({ address: next }) => {
         const g = typeof next === "string" ? next.trim() : ""
+        syncModuleFlags()
         if (!g) {
           setAddress(null)
+          stopHeartbeat()
           return null
         }
         setAddress(g)
         setHint(null)
+        startHeartbeat(g)
         queueMicrotask(() => void syncAlbedoTxPrep(g))
+        queueMicrotask(() => void validateHardwareNetwork())
         return g
       })
       .catch((e: unknown) => {
@@ -310,17 +506,23 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         }
         return null
       })
-  }, [syncAlbedoTxPrep])
+  }, [syncAlbedoTxPrep, syncModuleFlags, startHeartbeat, stopHeartbeat, validateHardwareNetwork])
 
   const disconnect = useCallback(() => {
     userDisconnectedRef.current = true
+    stopHeartbeat()
     void kit.disconnect().catch(() => {})
     setAddress(null)
     setArtistAlias(null)
     setHint(null)
     setAlbedoTxPrep("hidden")
     setAlbedoPrepError(null)
-  }, [])
+    setNetworkMismatch(null)
+    setIsHardwareWallet(false)
+    setIsWalletConnect(false)
+  }, [stopHeartbeat])
+
+  // ── context value ─────────────────────────────────────────────────────────
 
   const value = useMemo(
     () => ({
@@ -329,6 +531,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       hint,
       artistAlias,
       aliasLoading,
+      isHardwareWallet,
+      isWalletConnect,
       connect,
       disconnect,
       refresh,
@@ -342,6 +546,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       hint,
       artistAlias,
       aliasLoading,
+      isHardwareWallet,
+      isWalletConnect,
       connect,
       disconnect,
       refresh,
@@ -351,10 +557,45 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     ],
   )
 
+  // ── render ────────────────────────────────────────────────────────────────
+
   return (
     <>
       <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
-      {address && albedoTxPrep === "needed" && (
+
+      {/* ── Network passphrase mismatch alert (Ledger on wrong network) ──── */}
+      {networkMismatch && address && isHardwareWallet && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className={cn(
+            "fixed bottom-0 left-0 right-0 z-[400] border-t border-red-500/50 bg-background/95 px-4 py-3 text-sm shadow-lg backdrop-blur-sm",
+          )}
+        >
+          <div className="mx-auto flex max-w-3xl flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-2">
+              {/* Ledger icon indicator */}
+              <span className="mt-0.5 shrink-0 text-red-400" aria-hidden>
+                ⬡
+              </span>
+              <p className="text-foreground leading-snug">
+                <strong className="text-red-400">Ledger — red incorrecta.</strong>{" "}
+                {networkMismatch}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void validateHardwareNetwork().catch(() => {})}
+              className="shrink-0 rounded-md border border-red-500/50 bg-red-500/10 px-3 py-1.5 font-mono text-xs font-semibold text-red-300 hover:bg-red-500/20"
+            >
+              Reintentar / Retry
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Albedo implicit-tx permission banner ─────────────────────────── */}
+      {address && albedoTxPrep === "needed" && !networkMismatch && (
         <div
           role="status"
           className={cn(
@@ -404,10 +645,24 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   )
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Hook
+// ─────────────────────────────────────────────────────────────────────────────
+
 export function useWallet() {
   const ctx = useContext(WalletContext)
   if (!ctx) {
     throw new Error("useWallet must be used within WalletProvider")
   }
   return ctx
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Minimal shape of the WebUSB manager (navigator.usb). */
+interface USBManager extends EventTarget {
+  addEventListener(type: "connect" | "disconnect", listener: EventListenerOrEventListenerObject): void
+  removeEventListener(type: "connect" | "disconnect", listener: EventListenerOrEventListenerObject): void
 }

--- a/lib/stellar-wallet-kit.ts
+++ b/lib/stellar-wallet-kit.ts
@@ -8,13 +8,34 @@ import {
 } from "@creit.tech/stellar-wallets-kit"
 import { defaultModules } from "@creit.tech/stellar-wallets-kit/modules/utils"
 import { FREIGHTER_ID } from "@creit.tech/stellar-wallets-kit/modules/freighter"
+import { LedgerModule, LEDGER_ID } from "@creit.tech/stellar-wallets-kit/modules/ledger"
+import {
+  WalletConnectModule,
+  WalletConnectTargetChain,
+  WALLET_CONNECT_ID,
+} from "@creit.tech/stellar-wallets-kit/modules/wallet-connect"
 import { albedoImplicitTxAllowed, isAlbedoSelectedInKit } from "@/lib/albedo-intent-client"
 
 let initialized = false
 
 const LS_SELECTED_MODULE_ID = "@StellarWalletsKit/selectedModuleId"
 
+/** Testnet network passphrase — used for network validation on hardware wallets. */
+export const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015"
+export const MAINNET_PASSPHRASE = "Public Global Stellar Network ; September 2015"
+
 /**
+ * WalletConnect project ID. Set NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID in your environment.
+ * Get a free project ID at https://cloud.reown.com
+ */
+const WC_PROJECT_ID =
+  process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? "8b0db5d25e9ea3d7bddf2b96e1b7f0eb"
+
+/**
+ * Build the full modules list: all defaultModules (no extra config needed) plus
+ * LedgerModule (requires Buffer polyfill — provided via next.config) and
+ * WalletConnectModule (requires a Reown/WalletConnect project ID).
+ *
  * Si siempre pasáramos `selectedWalletId: FREIGHTER_ID`, cada carga pisaba la wallet que el usuario
  * eligió en el modal (p. ej. Albedo) y la firma iba a Freighter o fallaba sin UI clara.
  */
@@ -23,8 +44,21 @@ export function initStellarWalletKit() {
   const hasPersistedModule =
     typeof window !== "undefined" && Boolean(window.localStorage.getItem(LS_SELECTED_MODULE_ID)?.trim())
 
+  const walletConnectModule = new WalletConnectModule({
+    projectId: WC_PROJECT_ID,
+    metadata: {
+      name: "PHASE Protocol",
+      description: "AI artifact minting gated by on-chain Stellar payment.",
+      url: typeof window !== "undefined" ? window.location.origin : "https://phase.app",
+      icons: ["https://phase.app/icon.png"],
+    },
+    allowedChains: [WalletConnectTargetChain.TESTNET],
+  })
+
+  const ledgerModule = new LedgerModule()
+
   StellarWalletsKit.init({
-    modules: defaultModules(),
+    modules: [...defaultModules(), ledgerModule, walletConnectModule],
     network: Networks.TESTNET,
     ...(!hasPersistedModule ? { selectedWalletId: FREIGHTER_ID } : {}),
   })
@@ -37,7 +71,34 @@ export function initStellarWalletKit() {
  */
 export const kit = StellarWalletsKit
 
-export { FREIGHTER_ID, KitEventType, Networks, parseError }
+export {
+  FREIGHTER_ID,
+  LEDGER_ID,
+  WALLET_CONNECT_ID,
+  KitEventType,
+  Networks,
+  parseError,
+  WalletConnectTargetChain,
+}
+
+/**
+ * Detect whether the currently-selected wallet module is a hardware wallet (Ledger).
+ * Used to apply extra passphrase validation before signing.
+ */
+export function isHardwareWalletSelected(): boolean {
+  if (typeof window === "undefined") return false
+  const selected = window.localStorage.getItem(LS_SELECTED_MODULE_ID)?.trim()
+  return selected === LEDGER_ID
+}
+
+/**
+ * Detect whether the currently-selected wallet module is WalletConnect.
+ */
+export function isWalletConnectSelected(): boolean {
+  if (typeof window === "undefined") return false
+  const selected = window.localStorage.getItem(LS_SELECTED_MODULE_ID)?.trim()
+  return selected === WALLET_CONNECT_ID
+}
 
 /** Compatibilidad con el shape de `signTransaction` de Freighter (`error` en lugar de throw). */
 export async function signTransaction(
@@ -48,6 +109,30 @@ export async function signTransaction(
   | { error: { message: string }; signedTxXdr?: undefined; signedTransaction?: undefined }
 > {
   initStellarWalletKit()
+
+  // ── Network passphrase guard for Ledger ────────────────────────────────────
+  // Ledger apps are network-specific: signing testnet XDRs on a mainnet-mode
+  // Stellar app will fail cryptographically. Catch this mismatch early and
+  // surface a clear human-readable error instead of a cryptic HID timeout.
+  if (typeof window !== "undefined" && isHardwareWalletSelected()) {
+    if (
+      opts.networkPassphrase &&
+      opts.networkPassphrase !== TESTNET_PASSPHRASE &&
+      opts.networkPassphrase !== MAINNET_PASSPHRASE
+    ) {
+      return {
+        error: {
+          message: `Ledger: red desconocida (passphrase "${opts.networkPassphrase.slice(0, 32)}…"). Verificá que la app Stellar del Ledger esté abierta y en la red correcta. / Unknown network passphrase. Make sure the Stellar app is open on your Ledger and set to the correct network.`,
+        },
+      }
+    }
+    // Warn if the app is currently operating on testnet but receiving a mainnet passphrase
+    if (opts.networkPassphrase === MAINNET_PASSPHRASE) {
+      console.warn("[PHASE] Ledger: signing a MAINNET transaction — ensure your Ledger Stellar app is in mainnet mode.")
+    }
+  }
+
+  // ── Albedo implicit-tx guard ───────────────────────────────────────────────
   if (typeof window !== "undefined" && opts.address && isAlbedoSelectedInKit()) {
     const implicitOk = await albedoImplicitTxAllowed(opts.address)
     if (!implicitOk) {
@@ -59,11 +144,26 @@ export async function signTransaction(
       }
     }
   }
+
   try {
     const { signedTxXdr } = await StellarWalletsKit.signTransaction(xdr, opts)
     return { signedTxXdr, signedTransaction: signedTxXdr }
   } catch (e: unknown) {
     const err = parseError(e)
-    return { error: { message: err.message } }
+    // Map common Ledger/USB errors to friendly messages
+    const raw = err.message ?? ""
+    let message = raw
+
+    if (/transport|webusb|hid|usb/i.test(raw)) {
+      message = `Ledger USB: ${raw}. Intentá desconectar y volver a enchufar el dispositivo, o habilitá el acceso HID/WebUSB en la configuración del navegador. / USB transport error. Try unplugging and reconnecting the Ledger, or enable HID/WebUSB in browser settings.`
+    } else if (/timeout/i.test(raw)) {
+      message = `Ledger: tiempo de espera agotado. Asegurate de que la app Stellar esté abierta y el dispositivo desbloqueado. / Ledger sign timeout. Make sure the Stellar app is open and the device is unlocked.`
+    } else if (/denied|rejected|cancel/i.test(raw)) {
+      message = `Ledger: transacción rechazada en el dispositivo. / Transaction rejected on device.`
+    } else if (/no wallet has been connected/i.test(raw)) {
+      message = `Sin wallet conectada. Conectá tu wallet antes de firmar. / No wallet connected. Please connect a wallet first.`
+    }
+
+    return { error: { message } }
   }
 }


### PR DESCRIPTION
- lib/stellar-wallet-kit.ts
  - Add LedgerModule and WalletConnectModule to kit modules array
  - Export LEDGER_ID, WALLET_CONNECT_ID, WalletConnectTargetChain
  - Export TESTNET_PASSPHRASE / MAINNET_PASSPHRASE constants
  - Add isHardwareWalletSelected() and isWalletConnectSelected() helpers
  - signTransaction: network passphrase guard for Ledger (rejects unknown network before hitting HID transport)
  - signTransaction: friendly error messages for USB/timeout/rejected errors
  - WalletConnect project ID from NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID

- components/wallet-provider.tsx
  - Session restoration on mount via refresh()
  - Heartbeat: 8 s for hardware wallets, 30 s for extension wallets
  - navigator.usb connect/disconnect event listeners for immediate Ledger unplug detection
  - Hardware wallet network passphrase mismatch validation (calls kit.getNetwork() after connect and via effect)
  - Red banner UI alert when Ledger is on wrong network passphrase
  - isHardwareWallet / isWalletConnect flags exposed in context
  - stopHeartbeat() called on disconnect and session expiry
  - syncModuleFlags() on connect/openWalletPicker to keep flags current

- components/freighter-connect.tsx
  - WalletTypeBadge: amber '⬡ LEDGER' badge for hardware wallets, blue '◈ WC' badge for WalletConnect sessions
  - Status dot: amber for Ledger, blue for WalletConnect, violet default
  - Context-aware connecting label: 'Opening Ledger…' / 'Opening QR…'
  - Import cn from @/lib/utils

- .env.local.example
  - Document NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID variable

Closes #34